### PR TITLE
Added FormattedString and Span to elements registry.

### DIFF
--- a/src/nativescript-angular/element-registry.ts
+++ b/src/nativescript-angular/element-registry.ts
@@ -99,5 +99,7 @@ registerElement("TextView", () => require("ui/text-view").TextView);
 registerElement("TimePicker", () => require("ui/time-picker").TimePicker);
 registerElement("WebView", () => require("ui/web-view").WebView);
 registerElement("WrapLayout", () => require("ui/layouts/wrap-layout").WrapLayout);
+registerElement("FormattedString", () => require("text/formatted-string").FormattedString);
+registerElement("Span", () => require("text/span").Span);
 
 registerElement("DetachedContainer", () =>  require("ui/proxy-view-container").ProxyViewContainer, { skipAddToDom: true });


### PR DESCRIPTION
Just added FormattedString and Span to element registration file. FormattedString and Span should be used with the short-hand syntax.

```XML
<Label>
    <FormattedString>
        <Span text="Some text" fontAttributes="Bold" ></Span>
    </FormattedString>
</Label>
```