### PR TITLE
Fixed `$implicit` property setting.

### DIFF
--- a/src/nativescript-angular/directives/list-view-comp.ts
+++ b/src/nativescript-angular/directives/list-view-comp.ts
@@ -88,7 +88,7 @@ export class ListViewComponent {
     }
 
     public setupViewRef(viewRef: EmbeddedViewRef, data: any, index: number): void {
-        viewRef.setLocal('\$implicit', data.item);
+        viewRef.setLocal('\$implicit', data);
         viewRef.setLocal("item", data);
         viewRef.setLocal("index", index);
         viewRef.setLocal('even', (index % 2 == 0));


### PR DESCRIPTION
`$implicit` is set within `setupViewRef`method to `data.item` due to some copy/paste error.