### PR TITLE
Attaching a node to a parent remembering templateParent.

### DIFF
--- a/src/nativescript-angular/renderer.ts
+++ b/src/nativescript-angular/renderer.ts
@@ -114,11 +114,17 @@ export class NativeScriptRenderer extends Renderer {
 
     attachViewAfter(anchorNode: NgView, viewRootNodes: NgView[]) {
         traceLog('NativeScriptRenderer.attachViewAfter: ' + anchorNode.nodeName + ' ' + anchorNode);
-        const parent = (<NgView>anchorNode.parent || anchorNode.templateParent);
+        //HACK: The anchor.templateParent precedence and child.templateParent
+        //assignment are a workaround for RadSideDrawer.
+        //Remove it once we ship the fix in the RadSideDrawer directives.
+        const parent = (anchorNode.templateParent || <NgView>anchorNode.parent);
         const insertPosition = this.viewUtil.getChildIndex(parent, anchorNode);
 
         viewRootNodes.forEach((node, index) => {
             const childIndex = insertPosition + index + 1;
+            //Remember the template parent in case someone moves the view element
+            //before Angular attaches the next view.
+            node.templateParent = parent;
             this.viewUtil.insertChild(parent, node, childIndex);
             this.animateNodeEnter(node);
         });


### PR DESCRIPTION
Solves the problem of attaching a node and immediately moving it to another
location in the visual tree without Angular noticing. That breaks the next
attach as it will attach nodes to the new location instead of the original
one.

Originally reported for RadSideDrawer running on iOS.

//cc @vakrilov, @sophialazarova 