### PR TITLE
Update ShellJS

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "bugs": "http://www.telerik.com",
   "contributors": [
     "Hristo Deshev <hristo.deshev@telerik.com>"
-    ],
+  ],
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -33,13 +33,13 @@
   },
   "devDependencies": {
     "grunt": "0.4.5",
-    "grunt-contrib-copy": "0.8.0",
     "grunt-contrib-clean": "0.6.0",
-    "grunt-shell": "1.1.2",
-    "grunt-file": "1.0.2",
+    "grunt-contrib-copy": "0.8.0",
     "grunt-env": "0.4.4",
+    "grunt-file": "1.0.2",
+    "grunt-shell": "1.1.2",
     "grunt-ts": "5.0.0-beta.5",
-    "shelljs": "^0.5.3",
+    "shelljs": "^0.7.0",
     "typescript": "^1.8.10"
   },
   "peerDependencies": {


### PR DESCRIPTION
This uses the latest version of ShellJS. We improved some aspects of `cp('-R', ...)` in this latest release. Behavior for `cp()` should stay consistent for v0.7+.

Cheers!