### PR TITLE
Implement Renderer.setElementStyle.

### DIFF
--- a/.ctags-exclude
+++ b/.ctags-exclude
@@ -15,4 +15,4 @@ tests/lib
 tests/src/typings
 tests/typings
 web
-src/*.js
+*.js

--- a/ng-sample/app/app.ts
+++ b/ng-sample/app/app.ts
@@ -28,8 +28,8 @@ import {ModalTest} from "./examples/modal/modal-test";
 import {PlatfromDirectivesTest} from "./examples/platform-directives/platform-directives-test";
 import {RouterOutletTest} from "./examples/navigation/router-outlet-test";
 
-//nativeScriptBootstrap(RendererTest);
-nativeScriptBootstrap(TabViewTest);
+nativeScriptBootstrap(RendererTest);
+//nativeScriptBootstrap(TabViewTest);
 //nativeScriptBootstrap(Benchmark);
 //nativeScriptBootstrap(ListTest);
 //nativeScriptBootstrap(ListTestAsync);

--- a/ng-sample/app/examples/renderer-test.html
+++ b/ng-sample/app/examples/renderer-test.html
@@ -5,8 +5,8 @@
         <DatePicker [(ngModel)]='model.deliveryDate' ></DatePicker>
         <Label [text]='model.deliveryDate' ></Label>-->
     <SearchBar [(ngModel)]='model.search'></SearchBar>
-    <Label [text]='model.search'></Label>
-    <Label [text]='model.mydate | date:"fullDate"'></Label>
+    <Label [text]='model.search' [style.backgroundColor]="'hotpink'"></Label>
+    <Label [text]='model.mydate | date:"fullDate"' [ngStyle]="{'background-color': 'lime'}"></Label>
     <Slider [(ngModel)]='model.sliderTest'></Slider>
     <Label [text]='model.sliderTest'></Label>
     <ListPicker [items]='model.listPickerItems' [(ngModel)]='model.selectedIndex'></ListPicker>

--- a/ng-sample/package.json
+++ b/ng-sample/package.json
@@ -23,7 +23,7 @@
 	},
 	"homepage": "https://github.com/NativeScript/template-hello-world",
 	"dependencies": {
-		"tns-core-modules": "^2.0.0",
+		"tns-core-modules": "2.0.0-angular-7",
 		"nativescript-intl": "^0.0.2",
 		"@angular/common": "2.0.0-rc.1",
 		"@angular/compiler": "2.0.0-rc.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {},
   "dependencies": {
-    "tns-core-modules": "^2.0.0",
+    "tns-core-modules": "2.0.0-angular-7",
     "nativescript-intl": "^0.0.2",
     "@angular/common": "2.0.0-rc.1",
     "@angular/compiler": "2.0.0-rc.1",
@@ -43,7 +43,7 @@
     "typescript": "^1.8.10"
   },
   "peerDependencies": {
-    "tns-core-modules": ">=2.0.0 || >=2.0.0-2016 || >=2.0.0-angular-4"
+    "tns-core-modules": ">=2.0.0 || >=2.0.0-2016 || >=2.0.0-angular-7"
   },
   "nativescript": {}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-angular",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "",
   "homepage": "http://www.telerik.com",
   "bugs": "http://www.telerik.com",

--- a/tests/app/tests/style-properties.ts
+++ b/tests/app/tests/style-properties.ts
@@ -1,0 +1,36 @@
+//make sure you import mocha-config before @angular/core
+import {assert} from "./test-config";
+import {TextField} from "ui/text-field";
+import {Red, Lime} from "color/known-colors";
+import {NativeScriptRenderer, NativeScriptRootRenderer} from "nativescript-angular/renderer";
+import {device} from "platform";
+import {RenderComponentType} from '@angular/core/src/render/api';
+import {NgView} from "nativescript-angular/view-util";
+
+describe("Setting style properties", () => {
+    let renderer: NativeScriptRenderer = null;
+    let element: NgView = null;
+
+    beforeEach(() => {
+        const rootRenderer = new NativeScriptRootRenderer(null, device);
+        const componentType = new RenderComponentType("id", "templateUrl", 0,
+                                                            null, []);
+        renderer = new NativeScriptRenderer(rootRenderer, componentType);
+        element = <NgView><any>new TextField();
+    });
+
+    it("resolves hyphenated CSS names", () => {
+        renderer.setElementStyle(element, "background-color", "red");
+        assert.equal(Red, element.style.backgroundColor.hex);
+    });
+
+    it("resolves camel-cased JavaScript names", () => {
+        renderer.setElementStyle(element, "backgroundColor", "lime");
+        assert.equal(Lime, element.style.backgroundColor.hex);
+    });
+
+    it("resolves CSS shorthand properties", () => {
+        renderer.setElementStyle(element, "font", "12");
+        assert.equal(12, element.style.fontSize);
+    });
+})

--- a/tests/package.json
+++ b/tests/package.json
@@ -31,7 +31,7 @@
 	"homepage": "http://nativescript.org",
 	"dependencies": {
 		"nativescript-unit-test-runner": "^0.3.3",
-		"tns-core-modules": "^2.0.0",
+		"tns-core-modules": "2.0.0-angular-7",
 		"nativescript-intl": "^0.0.2",
 		"@angular/common": "2.0.0-rc.1",
 		"@angular/compiler": "2.0.0-rc.1",


### PR DESCRIPTION
Support style bindings:
 - `[ngStyle]="{'background-color': 'red'}"`
 - `[style.backgroundColor]="'red'"`

Fixes #229. Merge after NativeScript/NativeScript#2120 lands on master.