### PR TITLE
Fixed problem with ListView in ios when CustomTemplate is used.

### DIFF
--- a/ng-sample/app/examples/list/list-test.ts
+++ b/ng-sample/app/examples/list/list-test.ts
@@ -6,35 +6,32 @@ class DataItem {
     constructor(public id: number, public name: string) { }
 }
 
-// @Component({
-//     selector: 'item-component',
-//     template: `
-//         <StackLayout [class.odd]="odd" [class.even]="even">
-//             <Label [text]='"id: " + data.id'></Label>
-//             <Label [text]='"name: " + data.name'></Label>
-//         </StackLayout>
-//     `
-// })
-// export class ItemComponent {
-//     @Input() data: DataItem;
-//     @Input() odd: boolean;
-//     @Input() even: boolean;
-//     constructor() { }
-// }
+@Component({
+    selector: 'item-component',
+    template: `
+        <StackLayout [class.odd]="odd" [class.even]="even">
+            <Label [text]='"id: " + data.id'></Label>
+            <Label [text]='"name: " + data.name'></Label>
+        </StackLayout>
+    `
+})
+export class ItemComponent {
+    @Input() data: DataItem;
+    @Input() odd: boolean;
+    @Input() even: boolean;
+    constructor() { }
+}
 
 @Component({
     selector: 'list-test',
-    //directives: [ItemComponent],
+    directives: [ItemComponent],
     template: `
             <GridLayout rows="auto, *, auto, auto">
             <Label row="0" text="-==START==-" fontSize="20"></Label>
             <GridLayout row="1">
                 <ListView [items]="myItems" (itemTap)="onItemTap($event)">
                     <template let-item="item" let-i="index" let-odd="odd" let-even="even">
-                        <StackLayout [class.odd]="odd" [class.even]="even">
-                            <Label [text]='"index: " + i'></Label>
-                            <Label [text]='"[" + item.id +"] " + item.name'></Label>
-                        </StackLayout>
+                        <item-component [data]="item" [odd]="odd" [even]="even"></item-component>
                     </template>
                 </ListView>
             </GridLayout>
@@ -47,12 +44,12 @@ class DataItem {
     `,
     changeDetection: ChangeDetectionStrategy.OnPush
     // TEMPLATE WITH COMPONENT
-    // <template #item="item" #i="index" #odd="odd" #even="even">
+    // <template let-item="item" let-i="index" let-odd="odd" let-even="even">
     //     <item-component [data]="item" [odd]='odd' [even]='even'></item-component>
     // </template>
     
     // IN-PLACE TEMPLATE
-    // <template #item="item" #i="index" #odd="odd" #even="even">
+    // <template let-item="item" let-i="index" let-odd="odd" let-even="even">
     //     <StackLayout [class.odd]="odd" [class.even]="even">
     //         <Label [text]='"index: " + i'></Label>                        
     //         <Label [text]='"[" + item.id +"]" + item.name'></Label>
@@ -89,4 +86,3 @@ export class ListTest {
         label.text = "Alabala";
     }
 }
-


### PR DESCRIPTION
When custom template is used in angular ListView, a ProxyViewContainer, from custom template, is silently wrapped in a StackLayout which results in an incorrect view to store related angular EmbeddedView reference.
