### PR TITLE
fix(Http): export NS_HTTP_PROVIDERS to be used anywhere

### DIFF
--- a/nativescript-angular/application.ts
+++ b/nativescript-angular/application.ts
@@ -16,9 +16,7 @@ import {RootRenderer, Renderer} from '@angular/core/src/render/api';
 import {NativeScriptRootRenderer, NativeScriptRenderer} from './renderer';
 import {NativeScriptDomAdapter, NativeScriptElementSchemaRegistry, NativeScriptSanitizationService} from './dom-adapter';
 import {ElementSchemaRegistry, XHR, COMPILER_PROVIDERS, CompilerConfig} from '@angular/compiler';
-import {Http, XHRBackend, BrowserXhr, RequestOptions, ResponseOptions, XSRFStrategy} from '@angular/http';
 import {FileSystemXHR} from './http/xhr';
-import {NSXSRFStrategy, NSHttp} from './http/ns-http';
 import {NSFileSystem} from './file-system/ns-file-system';
 import {Parse5DomAdapter} from '@angular/platform-server/src/parse5_adapter';
 import {ExceptionHandler} from '@angular/core/src/facade/exception_handler';
@@ -112,18 +110,6 @@ export function bootstrap(appComponentType: any,
     if (isPresent(customProviders)) {
         appProviders.push(customProviders);
     }
-
-    // Http Setup    
-    // Since HTTP_PROVIDERS can be added with customProviders above, this must come after
-    appProviders.push([
-        provide(XSRFStrategy, { useValue: new NSXSRFStrategy() }),
-        NSFileSystem,
-        provide(Http, {
-            useFactory: (backend, options, nsFileSystem) => {
-                return new NSHttp(backend, options, nsFileSystem);
-            }, deps: [XHRBackend, RequestOptions, NSFileSystem]
-        })
-    ]);
 
     var platform = getPlatform();
     if (!isPresent(platform)) {

--- a/nativescript-angular/http.ts
+++ b/nativescript-angular/http.ts
@@ -1,0 +1,1 @@
+export * from './http/ns-http';

--- a/nativescript-angular/http/ns-http.ts
+++ b/nativescript-angular/http/ns-http.ts
@@ -1,5 +1,5 @@
 import {Injectable} from '@angular/core';
-import {Http, XHRConnection, ConnectionBackend, RequestOptions, RequestOptionsArgs, ResponseOptions, ResponseType, Response, Request, BrowserXhr} from '@angular/http';
+import {HTTP_PROVIDERS, Http, XHRBackend, XHRConnection, ConnectionBackend, RequestOptions, RequestOptionsArgs, ResponseOptions, ResponseType, Response, Request, BrowserXhr, XSRFStrategy} from '@angular/http';
 import {Observable} from 'rxjs/Observable';
 import 'rxjs/add/observable/fromPromise';
 import {NSFileSystem} from '../file-system/ns-file-system';
@@ -53,4 +53,14 @@ function responseOptions(body: string | Object, status: number, url: string): Re
     url: url
   }));
 }
+
+export const NS_HTTP_PROVIDERS: any[] = [
+  HTTP_PROVIDERS,
+  { provide: XSRFStrategy, useValue: new NSXSRFStrategy() },
+  NSFileSystem,
+  { provide: Http, useFactory: (backend, options, nsFileSystem) => {
+      return new NSHttp(backend, options, nsFileSystem);
+    }, deps: [XHRBackend, RequestOptions, NSFileSystem]
+  }
+];
 

--- a/ng-sample/app/app.ts
+++ b/ng-sample/app/app.ts
@@ -42,13 +42,13 @@ import { PageRouterOutletAppComponent, PageRouterOutletRouterProviders } from ".
 import { PageRouterOutletNestedAppComponent, PageRouterOutletNestedRouterProviders } from "./examples/router/page-router-outlet-nested-test"
 
 
-nativeScriptBootstrap(RendererTest);
+// nativeScriptBootstrap(RendererTest);
 //nativeScriptBootstrap(TabViewTest);
 //nativeScriptBootstrap(Benchmark);
 // nativeScriptBootstrap(ListTest);
 // nativeScriptBootstrap(ListTestAsync);
 //nativeScriptBootstrap(ImageTest);
-// nativeScriptBootstrap(HttpTest, [HTTP_PROVIDERS]);
+nativeScriptBootstrap(HttpTest);
 //nativeScriptBootstrap(ActionBarTest, [NS_ROUTER_PROVIDERS_DEPRECATED], { startPageActionBarHidden: false });
 //nativeScriptBootstrap(ActionBarTest, [NS_ROUTER_PROVIDERS_DEPRECATED]);
 //nativeScriptBootstrap(ModalTest);

--- a/ng-sample/app/examples/http/http-test.ts
+++ b/ng-sample/app/examples/http/http-test.ts
@@ -1,5 +1,6 @@
 import {Component} from '@angular/core';
 import {Http} from '@angular/http';
+import {NS_HTTP_PROVIDERS} from 'nativescript-angular/http';
 import 'rxjs/add/operator/map';
 
 /* IMPORTANT
@@ -22,7 +23,8 @@ https://blog.nraboy.com/2015/12/fix-ios-9-app-transport-security-issues-in-nativ
       `Button {
         margin-bottom:20;
       }`
-    ]
+    ],
+    providers: [NS_HTTP_PROVIDERS]
 })
 export class HttpTest {
   public title: string;

--- a/ng-sample/package.json
+++ b/ng-sample/package.json
@@ -1,65 +1,66 @@
 {
-	"name": "tns-template-hello-world",
-	"main": "app.js",
-	"version": "1.1.0",
-	"author": "Telerik <support@telerik.com>",
-	"description": "Nativescript hello-world project template",
-	"license": "BSD",
-	"keywords": [
-		"telerik",
-		"mobile",
-		"nativescript",
-		"{N}",
-		"tns",
-		"appbuilder",
-		"template"
-	],
-	"repository": {
-		"type": "git",
-		"url": "git://github.com/NativeScript/template-hello-world.git"
-	},
-	"bugs": {
-		"url": "https://github.com/NativeScript/template-hello-world/issues"
-	},
-	"homepage": "https://github.com/NativeScript/template-hello-world",
-	"dependencies": {
-		"tns-core-modules": ">=2.1.0 || >=2.1.0-2016",
-		"nativescript-angular": "^0.2.0",
-		"nativescript-intl": "^0.0.2",
-		"@angular/common": "2.0.0-rc.3",
-		"@angular/compiler": "2.0.0-rc.3",
-		"@angular/core": "2.0.0-rc.3",
-		"@angular/http": "2.0.0-rc.3",
-		"@angular/platform-browser": "2.0.0-rc.3",
-		"@angular/platform-browser-dynamic": "2.0.0-rc.3",
-		"@angular/platform-server": "2.0.0-rc.3",
-		"@angular/router-deprecated": "2.0.0-rc.2",
-		"@angular/router": "3.0.0-alpha.7",
-		"rxjs": "5.0.0-beta.6",
-		"zone.js": "^0.6.12",
-		"reflect-metadata": "^0.1.3",
-		"parse5": "1.4.2",
-		"punycode": "1.3.2",
-		"querystring": "0.2.0",
-		"url": "0.10.3"
-	},
-	"devDependencies": {
-		"babel-traverse": "6.9.0",
-		"babel-types": "6.10.0",
-		"babylon": "6.8.1",
-		"filewalker": "0.1.2",
-		"lazy": "1.0.11",
-		"nativescript-dev-typescript": "^0.3.1",
-		"nativescript-dev-webpack": "0.0.13",
-		"typescript": "^1.8.10"
-	},
-	"nativescript": {
-		"id": "org.nativescript.ngsample",
-		"tns-android": {
-			"version": "2.1.1"
-		},
-		"tns-ios": {
-			"version": "2.1.0"
-		}
-	}
+  "name": "tns-template-hello-world",
+  "main": "app.js",
+  "version": "1.1.0",
+  "author": "Telerik <support@telerik.com>",
+  "description": "Nativescript hello-world project template",
+  "license": "BSD",
+  "keywords": [
+    "telerik",
+    "mobile",
+    "nativescript",
+    "{N}",
+    "tns",
+    "appbuilder",
+    "template"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/NativeScript/template-hello-world.git"
+  },
+  "bugs": {
+    "url": "https://github.com/NativeScript/template-hello-world/issues"
+  },
+  "homepage": "https://github.com/NativeScript/template-hello-world",
+  "dependencies": {
+    "tns-core-modules": ">=2.1.0 || >=2.1.0-2016",
+    "nativescript-angular": "^0.2.0",
+    "nativescript-intl": "^0.0.2",
+    "@angular/common": "2.0.0-rc.3",
+    "@angular/compiler": "2.0.0-rc.3",
+    "@angular/core": "2.0.0-rc.3",
+    "@angular/http": "2.0.0-rc.3",
+    "@angular/platform-browser": "2.0.0-rc.3",
+    "@angular/platform-browser-dynamic": "2.0.0-rc.3",
+    "@angular/platform-server": "2.0.0-rc.3",
+    "@angular/router-deprecated": "2.0.0-rc.2",
+    "@angular/router": "3.0.0-alpha.7",
+    "rxjs": "5.0.0-beta.6",
+    "zone.js": "^0.6.12",
+    "reflect-metadata": "^0.1.3",
+    "parse5": "1.4.2",
+    "punycode": "1.3.2",
+    "querystring": "0.2.0",
+    "url": "0.10.3"
+  },
+  "devDependencies": {
+    "babel-traverse": "6.9.0",
+    "babel-types": "6.10.0",
+    "babylon": "6.8.1",
+    "filewalker": "0.1.2",
+    "lazy": "1.0.11",
+    "nativescript-dev-typescript": "^0.3.1",
+    "nativescript-dev-webpack": "0.0.13",
+    "shelljs": "^0.7.0",
+    "typescript": "^1.8.10"
+  },
+  "nativescript": {
+    "id": "org.nativescript.ngsample",
+    "tns-android": {
+      "version": "2.1.1"
+    },
+    "tns-ios": {
+      "version": "2.1.0"
+    }
+  }
 }


### PR DESCRIPTION
This can now be imported from anywhere and used in either `nativeScriptBootstrap` providers array or `Component` `providers` array:

```
import {NS_HTTP_PROVIDERS} from 'nativescript-angular/http';
```

I have also added a Guide to the Wiki regarding `Http`:
https://github.com/NativeScript/nativescript-angular/wiki/Http

closes https://github.com/NativeScript/nativescript-angular/issues/305