### PR TITLE
cssClasses renamed to ngCssClasses

### DIFF
--- a/nativescript-angular/element-registry.ts
+++ b/nativescript-angular/element-registry.ts
@@ -12,7 +12,7 @@ export interface ViewClassMeta {
 export interface ViewExtensions {
     nodeName: string;
     templateParent: NgView;
-    cssClasses: Map<string, boolean>;
+    ngCssClasses: Map<string, boolean>;
     meta: ViewClassMeta;
 }
 
@@ -22,7 +22,7 @@ export interface ViewClass {
 
 const defaultViewMeta: ViewClassMeta = {
     skipAddToDom: false,
-}
+};
 
 const elementMap: Map<string, { resolver: ViewResolver, meta?: ViewClassMeta }> = new Map<string, { resolver: ViewResolver, meta?: ViewClassMeta }>();
 const camelCaseSplit = /([a-z0-9])([A-Z])/g;

--- a/nativescript-angular/view-util.ts
+++ b/nativescript-angular/view-util.ts
@@ -3,13 +3,11 @@ import {View} from "ui/core/view";
 import {Placeholder} from "ui/placeholder";
 import {ContentView} from 'ui/content-view';
 import {LayoutBase} from 'ui/layouts/layout-base';
-import {ViewClass, getViewClass, getViewMeta, isKnownView, ViewExtensions, NgView, ViewClassMeta} from './element-registry';
+import {ViewClass, getViewClass, getViewMeta, isKnownView, ViewExtensions, NgView} from './element-registry';
 import {getSpecialPropertySetter} from "ui/builder/special-properties";
-import * as styleProperty from "ui/styling/style-property";
 import {StyleProperty, getPropertyByName, withStyleProperty} from "ui/styling/style-property";
 import {ValueSource} from "ui/core/dependency-observable";
-import { ActionBar, ActionItem, NavigationButton } from "ui/action-bar";
-import {device, platformNames, Device} from "platform";
+import {platformNames, Device} from "platform";
 import {rendererLog as traceLog, styleError} from "./trace";
 
 const IOS_PREFX: string = "@ios:";
@@ -160,7 +158,7 @@ export class ViewUtil {
     }
 
     private platformFilter(attribute: string): string {
-        var lowered = attribute.toLowerCase();
+        let lowered = attribute.toLowerCase();
         if (lowered.indexOf(IOS_PREFX) === 0) {
             if (this.isIos) {
                 return attribute.substr(IOS_PREFX.length);
@@ -194,7 +192,7 @@ export class ViewUtil {
             let propMap = this.getProperties(view);
             let i = 0;
             while (i < properties.length - 1 && isDefined(view)) {
-                var prop = properties[i];
+                let prop = properties[i];
                 if (propMap.has(prop)) {
                     prop = propMap.get(prop);
                 }
@@ -237,7 +235,7 @@ export class ViewUtil {
             return value;
         }
 
-        var valueAsNumber = +value;
+        let valueAsNumber = +value;
         if (!isNaN(valueAsNumber)) {
             return valueAsNumber;
         } else if (value && (value.toLowerCase() === "true" || value.toLowerCase() === "false")) {
@@ -254,8 +252,8 @@ export class ViewUtil {
         }
 
         if (!propertyMaps.has(type)) {
-            var propMap = new Map<string, string>();
-            for (var propName in instance) {
+            let propMap = new Map<string, string>();
+            for (let propName in instance) {
                 propMap.set(propName.toLowerCase(), propName);
             }
             propertyMaps.set(type, propMap);
@@ -264,10 +262,10 @@ export class ViewUtil {
     }
 
     private cssClasses(view: NgView) {
-        if (!view.cssClasses) {
-            view.cssClasses = new Map<string, boolean>();
+        if (!view.ngCssClasses) {
+            view.ngCssClasses = new Map<string, boolean>();
         }
-        return view.cssClasses;
+        return view.ngCssClasses;
     }
 
     public addClass(view: NgView, className: string): void {
@@ -317,7 +315,6 @@ export class ViewUtil {
         withStyleProperty(name, resolvedValue, (property, value) => {
             if (isString(property)) {
                 //Fall back to resolving property by name.
-                const propertyName = <string>property;
                 const resolvedProperty = getPropertyByName(name);
                 if (resolvedProperty) {
                     this.setStyleValue(view, resolvedProperty, resolvedValue);

--- a/tests/app/tests/property-sets.ts
+++ b/tests/app/tests/property-sets.ts
@@ -1,19 +1,17 @@
 //make sure you import mocha-config before @angular/core
 import {assert} from "./test-config";
-import {bootstrap} from "nativescript-angular/application";
-import {Component} from "@angular/core";
 import {View} from "ui/core/view";
 import {ViewUtil} from "nativescript-angular/view-util";
 import {NgView, ViewExtensions, ViewClassMeta} from "nativescript-angular/element-registry";
 import {Red} from "color/known-colors";
-import {device, Device, platformNames} from "platform";
+import {device, platformNames} from "platform";
 import {createDevice} from "./test-utils";
 
 class TestView extends View implements ViewExtensions {
     public nodeName: string = "TestView";
     public templateParent: NgView = null;
     public meta: ViewClassMeta = { skipAddToDom: false };
-    public cssClasses: Map<string, boolean> = new Map<string, boolean>();
+    public ngCssClasses: Map<string, boolean> = new Map<string, boolean>();
 
     public stringValue: string = "";
     public numValue: number = 0;
@@ -26,91 +24,91 @@ const iosDevice = createDevice(platformNames.ios);
 const androidDevice = createDevice(platformNames.android);
 
 describe('setting View properties', () => {
-    var viewUtil: ViewUtil;
+    let viewUtil: ViewUtil;
     before(() => {
         viewUtil = new ViewUtil(device);
-    })
+    });
 
     it('preserves string values', () => {
         let view = new TestView();
-        viewUtil.setProperty(view, "stringValue", "blah")
+        viewUtil.setProperty(view, "stringValue", "blah");
         assert.equal("blah", view.stringValue);
     });
 
     it('converts number values', () => {
         let view = new TestView();
-        viewUtil.setProperty(view, "numValue", "42")
+        viewUtil.setProperty(view, "numValue", "42");
         assert.strictEqual(42, view.numValue);
-        viewUtil.setProperty(view, "numValue", 0)
+        viewUtil.setProperty(view, "numValue", 0);
         assert.strictEqual(0, view.numValue);
     });
 
     it('converts boolean values', () => {
         let view = new TestView();
-        viewUtil.setProperty(view, "boolValue", "true")
+        viewUtil.setProperty(view, "boolValue", "true");
         assert.strictEqual(true, view.boolValue);
-        viewUtil.setProperty(view, "boolValue", "false")
+        viewUtil.setProperty(view, "boolValue", "false");
         assert.strictEqual(false, view.boolValue);
     });
 
     it('sets style values', () => {
         let view = new TestView();
-        viewUtil.setProperty(view, "style", "color: red")
+        viewUtil.setProperty(view, "style", "color: red");
         assert.equal(Red, view.style.color.hex);
     });
 
     it('doesn\'t convert blank strings', () => {
         let view = new TestView();
-        viewUtil.setProperty(view, "stringValue", "")
+        viewUtil.setProperty(view, "stringValue", "");
         assert.strictEqual("", view.stringValue);
     });
 
     it('doesn\'t convert booleans', () => {
         let view = new TestView();
-        viewUtil.setProperty(view, "boolValue", true)
+        viewUtil.setProperty(view, "boolValue", true);
         assert.strictEqual(true, view.boolValue);
-        viewUtil.setProperty(view, "boolValue", false)
+        viewUtil.setProperty(view, "boolValue", false);
         assert.strictEqual(false, view.boolValue);
     });
 
     it('preserves objects', () => {
         let value = { name: "Jim", age: 23 };
         let view = new TestView();
-        viewUtil.setProperty(view, "anyValue", value)
+        viewUtil.setProperty(view, "anyValue", value);
         assert.deepEqual(value, view.anyValue);
     });
 
     it('sets nested properties', () => {
         let view = new TestView();
-        viewUtil.setProperty(view, "nested.property", "blah")
+        viewUtil.setProperty(view, "nested.property", "blah");
         assert.strictEqual("blah", view.nested.property);
     });
 
     it('sets ios property in ios', () => {
         let view = new TestView();
         let testUtil = new ViewUtil(iosDevice);
-        testUtil.setProperty(view, "@ios:anyValue", "blah")
+        testUtil.setProperty(view, "@ios:anyValue", "blah");
         assert.strictEqual("blah", view.anyValue);
     });
 
     it('doesn\'t set android property in ios', () => {
         let view = new TestView();
         let testUtil = new ViewUtil(iosDevice);
-        testUtil.setProperty(view, "@android:anyValue", "blah")
+        testUtil.setProperty(view, "@android:anyValue", "blah");
         assert.isUndefined(view.anyValue);
     });
 
     it('sets android property in android', () => {
         let view = new TestView();
         let testUtil = new ViewUtil(androidDevice);
-        testUtil.setProperty(view, "@android:anyValue", "blah")
+        testUtil.setProperty(view, "@android:anyValue", "blah");
         assert.strictEqual("blah", view.anyValue);
     });
 
     it('doesn\'t set ios property in android', () => {
         let view = new TestView();
         let testUtil = new ViewUtil(androidDevice);
-        testUtil.setProperty(view, "@ios:anyValue", "blah")
+        testUtil.setProperty(view, "@ios:anyValue", "blah");
         assert.isUndefined(view.anyValue);
     });
 });


### PR DESCRIPTION
As of NativeScript/NativeScript#2465 there is a `cssClasses` field in the view.
We need to rename the one we use in the `ViewExtensions`

cc @PanayotCankov 