### PR TITLE
Include modalDialogHost directive

### DIFF
--- a/ng-sample/app/examples/modal/modal-test.ts
+++ b/ng-sample/app/examples/modal/modal-test.ts
@@ -6,6 +6,7 @@ import {ModalContent} from "./modal-content";
 @Component({
     selector: 'modal-test',
     providers: [ModalDialogService],
+    directives: [ModalDialogHost],
     template: `
     <GridLayout rows="*, auto" modal-dialog-host>
         <StackLayout verticalAlignment="top" margin="12">


### PR DESCRIPTION
Without this, I get the error "No viewContainerRef: Make sure you have the modal-dialog-host directive inside your component." when I try to follow the example. 