### PR TITLE
RouterExtensions.canGoBack() method added

### DIFF
--- a/nativescript-angular/router/ns-location-strategy.ts
+++ b/nativescript-angular/router/ns-location-strategy.ts
@@ -113,6 +113,10 @@ export class NSLocationStrategy extends LocationStrategy {
 
     }
 
+    canGoBack() {
+        return this.states.length > 1;
+    }
+
     onPopState(fn: (_: any) => any): void {
         routerLog("NSLocationStrategy.onPopState");
         this.popStateCallbacks.push(fn);

--- a/nativescript-angular/router/router-extensions.ts
+++ b/nativescript-angular/router/router-extensions.ts
@@ -28,6 +28,10 @@ export class RouterExtensions {
         this.locationStrategy.back();
     }
 
+    public canGoBack() {
+        return this.locationStrategy.canGoBack();
+    }
+
     public backToPreviousPage() {
         this.frame.goBack();
     }

--- a/tests/app/tests/ns-location-strategy.ts
+++ b/tests/app/tests/ns-location-strategy.ts
@@ -80,6 +80,20 @@ describe('NSLocationStrategy', () => {
         assert.equal(strategy.path(), "/test");
     });
 
+    it("canGoBack() return false initially", () => {
+        const strategy = initStrategy();
+
+        assert.isFalse(strategy.canGoBack(), "canGoBack() should reutrn false if there are no navigations");
+    });
+
+    it("canGoBack() return true after navigation", () => {
+        const strategy = initStrategy();
+
+        strategy.pushState(null, "test", "/test", null);
+
+        assert.isTrue(strategy.canGoBack(), "canGoBack() should reutrn true after navigation");
+    });
+
     it("back() calls onPopState", () => {
         const strategy = initStrategy();
         let popCount = 0;


### PR DESCRIPTION
Add a `canGoBack()` method to `RouterExtensions`

Related to #477