### PR TITLE
Modal dialogs reafactoring

### DIFF
--- a/nativescript-angular/directives/dialogs.ts
+++ b/nativescript-angular/directives/dialogs.ts
@@ -1,14 +1,15 @@
 import {
     ReflectiveInjector, ComponentFactoryResolver, ViewContainerRef,
-    Injector, Type, Injectable, ComponentRef, Directive
+    Type, Injectable, ComponentRef, Directive
 } from '@angular/core';
-import {Page} from 'ui/page';
-import {View} from 'ui/core/view';
-import {DetachedLoader} from '../common/detached-loader';
+import { Page } from 'ui/page';
+import { View } from 'ui/core/view';
+import { DetachedLoader } from '../common/detached-loader';
 
 export interface ModalDialogOptions {
     context?: any;
     fullscreen?: boolean;
+    viewContainerRef?: ViewContainerRef;
 }
 
 export class ModalDialogParams {
@@ -22,52 +23,61 @@ export class ModalDialogParams {
 export class ModalDialogService {
     private containerRef: ViewContainerRef;
 
-    constructor(
-        private page: Page,
-        private resolver: ComponentFactoryResolver) {
-    }
-
     public registerViewContainerRef(ref: ViewContainerRef) {
         this.containerRef = ref;
     }
 
     public showModal(type: Type<any>, options: ModalDialogOptions): Promise<any> {
-        if (!this.containerRef) {
-            throw new Error("No viewContainerRef: Make sure you have the modal-dialog-host directive inside your component.");
+        let viewContainerRef = options.viewContainerRef || this.containerRef;
+
+        if (!viewContainerRef) {
+            throw new Error("No viewContainerRef: Make sure you pass viewContainerRef in ModalDialogOptions.");
         }
+
+        const parentPage: Page = viewContainerRef.injector.get(Page);
+        const resolver: ComponentFactoryResolver = viewContainerRef.injector.get(ComponentFactoryResolver);
+
         return new Promise((resolve, reject) => {
-            setTimeout(() => this.showDialog(type, options, resolve), 10);
+            setTimeout(() => ModalDialogService.showDialog(type, options, resolve, viewContainerRef, resolver, parentPage), 10);
         });
     }
 
-    private showDialog(type: Type<any>, options: ModalDialogOptions, doneCallback): void {
+    private static showDialog(
+        type: Type<any>,
+        options: ModalDialogOptions,
+        doneCallback,
+        containerRef: ViewContainerRef,
+        resolver: ComponentFactoryResolver,
+        parentPage: Page): void {
+
         const page = new Page();
 
-        var detachedLoaderRef: ComponentRef<DetachedLoader>;
+        let detachedLoaderRef: ComponentRef<DetachedLoader>;
         const closeCallback = (...args) => {
             doneCallback.apply(undefined, args);
             page.closeModal();
             detachedLoaderRef.destroy();
-        }
+        };
+
         const modalParams = new ModalDialogParams(options.context, closeCallback);
 
         const providers = ReflectiveInjector.resolve([
-            {provide: Page, useValue: page },
-            {provide: ModalDialogParams, useValue: modalParams },
+            { provide: Page, useValue: page },
+            { provide: ModalDialogParams, useValue: modalParams },
         ]);
 
-        const childInjector = ReflectiveInjector.fromResolvedProviders(providers, this.containerRef.parentInjector);
-        const detachedFactory = this.resolver.resolveComponentFactory(DetachedLoader);
-        detachedLoaderRef = this.containerRef.createComponent(detachedFactory, -1, childInjector, null)
+        const childInjector = ReflectiveInjector.fromResolvedProviders(providers, containerRef.parentInjector);
+        const detachedFactory = resolver.resolveComponentFactory(DetachedLoader);
+        detachedLoaderRef = containerRef.createComponent(detachedFactory, -1, childInjector, null);
         detachedLoaderRef.instance.loadComponent(type).then((compRef) => {
             const componentView = <View>compRef.location.nativeElement;
-            
+
             if (componentView.parent) {
                 (<any>componentView.parent).removeChild(componentView);
             }
-            
+
             page.content = componentView;
-            this.page.showModal(page, options.context, closeCallback, options.fullscreen);
+            parentPage.showModal(page, options.context, closeCallback, options.fullscreen);
         });
     }
 }
@@ -78,6 +88,8 @@ export class ModalDialogService {
 })
 export class ModalDialogHost {
     constructor(containerRef: ViewContainerRef, modalService: ModalDialogService) {
+        console.log("ModalDialogHost is deprecated. Call ModalDialogService.showModal() by passing ViewContainerRef in the options instead.")
+
         modalService.registerViewContainerRef(containerRef);
     }
 } 

--- a/nativescript-angular/platform.ts
+++ b/nativescript-angular/platform.ts
@@ -16,7 +16,7 @@ import {CommonModule} from '@angular/common';
 import {Provider} from '@angular/core';
 import {NativeScriptRootRenderer, NativeScriptRenderer} from './renderer';
 import {DetachedLoader} from "./common/detached-loader";
-import {ModalDialogHost} from "./directives/dialogs";
+import {ModalDialogHost, ModalDialogService} from "./directives/dialogs";
 import {
     Type,
     Injector,
@@ -84,6 +84,7 @@ export interface AppOptions {
         NativeScriptRenderer,
         {provide: Renderer, useClass: NativeScriptRenderer},
         {provide: Sanitizer, useClass: NativeScriptSanitizer},
+        ModalDialogService
     ],
     entryComponents: [
         DetachedLoader,

--- a/ng-sample/app/examples/modal/modal-test.ts
+++ b/ng-sample/app/examples/modal/modal-test.ts
@@ -1,13 +1,12 @@
-import {Component} from '@angular/core';
+import { Component, ViewContainerRef } from '@angular/core';
 import * as dialogs from "ui/dialogs";
-import {ModalDialogService, ModalDialogOptions, ModalDialogHost} from "nativescript-angular/directives/dialogs";
-import {ModalContent} from "./modal-content";
+import { ModalDialogService, ModalDialogOptions } from "nativescript-angular/directives/dialogs";
+import { ModalContent} from "./modal-content";
 
 @Component({
     selector: 'modal-test',
-    providers: [ModalDialogService],
     template: `
-    <GridLayout rows="*, auto" modal-dialog-host>
+    <GridLayout rows="*, auto">
         <StackLayout verticalAlignment="top" margin="12">
             <Button text="show component" (tap)="showModal(false)"></Button>
             <Button text="show component fullscreen" (tap)="showModal(true)"></Button>
@@ -27,7 +26,7 @@ import {ModalContent} from "./modal-content";
 export class ModalTest {
     public result: string = "result";
 
-    constructor(private modal: ModalDialogService) {
+    constructor(private modal: ModalDialogService, private vcRef: ViewContainerRef) {
     }
 
     static entries = [
@@ -39,14 +38,15 @@ export class ModalTest {
     ];
 
     public showModal(fullscreen: boolean) {
-        var options: ModalDialogOptions = {
+        const options: ModalDialogOptions = {
             context: { promptMsg: "This is the prompt message!" },
-            fullscreen: fullscreen
+            fullscreen: fullscreen,
+            viewContainerRef: this.vcRef
         };
 
         this.modal.showModal(ModalContent, options).then((res: string) => {
             this.result = res || "empty result";
-        })
+        });
     }
 
     public showAlert() {


### PR DESCRIPTION
`ModalDialogHost` is deprecated. You can now call `ModalDialogService.showModal()` and pass a `ViewContainerRef` in the options instead (you will have to inject the `ViewContainerRef`). 
This approach is similar to [angular-material2 dialog](https://github.com/angular/material2/blob/0e0ff0e7aae4a4f87ad92e17bc1af14e20a3e17a/src/demo-app/dialog/dialog-demo.ts#L14-L29).

Related to #460 and #430