### PR TITLE
Support for custom page factory providers

### DIFF
--- a/nativescript-angular/directives/dialogs.ts
+++ b/nativescript-angular/directives/dialogs.ts
@@ -5,6 +5,7 @@ import {
 import { Page } from 'ui/page';
 import { View } from 'ui/core/view';
 import { DetachedLoader } from '../common/detached-loader';
+import { PageFactory, PAGE_FACTORY } from '../platform-providers';
 
 export interface ModalDialogOptions {
     context?: any;
@@ -36,9 +37,10 @@ export class ModalDialogService {
 
         const parentPage: Page = viewContainerRef.injector.get(Page);
         const resolver: ComponentFactoryResolver = viewContainerRef.injector.get(ComponentFactoryResolver);
+        const pageFactory: PageFactory = viewContainerRef.injector.get(PAGE_FACTORY);
 
         return new Promise((resolve, reject) => {
-            setTimeout(() => ModalDialogService.showDialog(type, options, resolve, viewContainerRef, resolver, parentPage), 10);
+            setTimeout(() => ModalDialogService.showDialog(type, options, resolve, viewContainerRef, resolver, parentPage, pageFactory), 10);
         });
     }
 
@@ -48,9 +50,10 @@ export class ModalDialogService {
         doneCallback,
         containerRef: ViewContainerRef,
         resolver: ComponentFactoryResolver,
-        parentPage: Page): void {
+        parentPage: Page,
+        pageFactory: PageFactory): void {
 
-        const page = new Page();
+        const page = pageFactory({ isModal: true, componentType: type });
 
         let detachedLoaderRef: ComponentRef<DetachedLoader>;
         const closeCallback = (...args) => {

--- a/nativescript-angular/platform-providers.ts
+++ b/nativescript-angular/platform-providers.ts
@@ -1,12 +1,11 @@
 import { topmost, Frame } from 'ui/frame';
 import { Page } from 'ui/page';
-import { OpaqueToken } from '@angular/core';
+import { OpaqueToken, Type } from '@angular/core';
 import { device, Device } from "platform";
 
 export const APP_ROOT_VIEW = new OpaqueToken('App Root View');
 export const DEVICE = new OpaqueToken('platfrom device');
-
-export const defaultPageProvider = { provide: Page, useFactory: getDefaultPage };
+export const PAGE_FACTORY = new OpaqueToken('page factory');
 
 export function getDefaultPage(): Page {
     const frame = topmost();
@@ -16,7 +15,21 @@ export function getDefaultPage(): Page {
         return null;
     }
 }
+export const defaultPageProvider = { provide: Page, useFactory: getDefaultPage };
 
 export const defaultFrameProvider = { provide: Frame, useFactory: topmost };
 
 export const defaultDeviceProvider = { provide: DEVICE, useValue: device };
+
+export type PageFactory = (options: PageFactoryOptions) => Page;
+export interface PageFactoryOptions {
+    isBootstrap?: boolean,
+    isLivesync?:boolean,
+    isModal?: boolean,
+    isNavigation?: boolean,
+    componentType?: any
+}
+export const defaultPageFactory: PageFactory = function (opts: PageFactoryOptions) {
+    return new Page();
+}
+export const defaultPageFactoryProvider = { provide: PAGE_FACTORY, useValue: defaultPageFactory };

--- a/ng-sample/app/app.ts
+++ b/ng-sample/app/app.ts
@@ -13,10 +13,13 @@ import { NativeScriptRouterModule } from "nativescript-angular/router";
 import { NativeScriptFormsModule } from "nativescript-angular/forms";
 import { NativeScriptHttpModule } from "nativescript-angular/http";
 import { rendererTraceCategory, routerTraceCategory, listViewTraceCategory } from "nativescript-angular/trace";
+import { PAGE_FACTORY, PageFactory, PageFactoryOptions } from "nativescript-angular/platform-providers";
+import { Page } from "ui/page";
+import { Color } from "color";
 
 import trace = require("trace");
 // trace.setCategories(rendererTraceCategory);
-trace.setCategories(routerTraceCategory);
+// trace.setCategories(routerTraceCategory);
 // trace.setCategories(listViewTraceCategory);
 trace.enable();
 
@@ -62,7 +65,7 @@ import { AnimationStatesTest } from "./examples/animation/animation-states-test"
     ],
     providers: []
 })
-class ExampleModule {}
+class ExampleModule { }
 
 function makeExampleModule(componentType) {
     let imports: any[] = [ExampleModule];
@@ -93,25 +96,35 @@ function makeExampleModule(componentType) {
         providers: providers,
         exports: exports,
     })
-    class ExampleModuleForComponent {}
+    class ExampleModuleForComponent { }
 
     return ExampleModuleForComponent;
 }
 
-platformNativeScriptDynamic().bootstrapModule(makeExampleModule(RendererTest));
+const customPageFactoryProvider = {
+    provide: PAGE_FACTORY,
+    useValue: (opts: PageFactoryOptions) => {
+        const page = new Page();
+        page.backgroundColor = opts.isModal ? new Color("lightblue") : new Color("lightgreen");
+        return page;
+    }
+};
+
+// platformNativeScriptDynamic().bootstrapModule(makeExampleModule(RendererTest));
+platformNativeScriptDynamic(undefined, [customPageFactoryProvider]).bootstrapModule(makeExampleModule(RendererTest));
 //platformNativeScriptDynamic().bootstrapModule(makeExampleModule(TabViewTest));
 //platformNativeScriptDynamic().bootstrapModule(makeExampleModule(Benchmark));
 //platformNativeScriptDynamic().bootstrapModule(makeExampleModule(ListTest));
 //platformNativeScriptDynamic().bootstrapModule(makeExampleModule(ListTestAsync));
 //platformNativeScriptDynamic().bootstrapModule(makeExampleModule(ImageTest));
-//platformNativeScriptDynamic().bootstrapModule(makeExampleModule(ModalTest));
+// platformNativeScriptDynamic().bootstrapModule(makeExampleModule(ModalTest));
 //platformNativeScriptDynamic().bootstrapModule(makeExampleModule(HttpTest));
 //platformNativeScriptDynamic().bootstrapModule(makeExampleModule(PlatfromDirectivesTest));
 //platformNativeScriptDynamic().bootstrapModule(makeExampleModule(ActionBarTest));
 
 //new router
 //platformNativeScriptDynamic().bootstrapModule(makeExampleModule(RouterOutletAppComponent));
-//platformNativeScriptDynamic().bootstrapModule(makeExampleModule(PageRouterOutletAppComponent));
+// platformNativeScriptDynamic().bootstrapModule(makeExampleModule(PageRouterOutletAppComponent));
 //platformNativeScriptDynamic().bootstrapModule(makeExampleModule(PageRouterOutletNestedAppComponent));
 //platformNativeScriptDynamic().bootstrapModule(makeExampleModule(ClearHistoryAppComponent));
 //platformNativeScriptDynamic().bootstrapModule(makeExampleModule(LoginAppComponent));

--- a/ng-sample/package.json
+++ b/ng-sample/package.json
@@ -29,6 +29,7 @@
     "@angular/core": "~2.1.1",
     "@angular/common": "~2.1.1",
     "@angular/compiler": "~2.1.1",
+    "@angular/forms": "~2.1.1",
     "@angular/http": "~2.1.1",
     "@angular/platform-browser": "~2.1.1",
     "@angular/platform-browser-dynamic": "~2.1.1",


### PR DESCRIPTION
Add support for providing custom PageFactory. The factory is used when creating pages when:
- Bootstraping/livsyncing the application.
- Doing page navigation (with `<page-router-outlet`).
- When showing custom modal dialogs.

Resolves #394 

cc @VladimirAmiorkov 
