### PR TITLE
Fix TabView value accessor selector.

### DIFF
--- a/nativescript-angular/value-accessors/selectedIndex-value-accessor.ts
+++ b/nativescript-angular/value-accessors/selectedIndex-value-accessor.ts
@@ -20,7 +20,7 @@ export type SelectableView = {selectedIndex: number} & View;
  */
 @Directive({
     // tslint:disable:max-line-length
-    selector: "SegmentedBar[ngModel], segmentedBar[ngModel], segmented-bar[ngModel], ListPicker[ngModel], listPicker[ngModel], list-picker[ngModel], TabView[ngModel] tabView[ngModel], tab-view[ngModel]",
+    selector: "SegmentedBar[ngModel], segmentedBar[ngModel], segmented-bar[ngModel], ListPicker[ngModel], listPicker[ngModel], list-picker[ngModel], TabView[ngModel], tabView[ngModel], tab-view[ngModel]",
     host: { "(selectedIndexChange)": "onChange($event.value)" },
     providers: [SELECTED_INDEX_VALUE_ACCESSOR]
 })


### PR DESCRIPTION
The TabView CSS selector was wrong and broke directive registration.

Fixes #551 