### PR TITLE
FIX: Adding template anchors to ContentView

### DIFF
--- a/nativescript-angular/directives/action-bar.ts
+++ b/nativescript-angular/directives/action-bar.ts
@@ -1,9 +1,9 @@
 import { Directive, Component, ElementRef, Optional } from "@angular/core";
 import { ActionItem, ActionBar, NavigationButton } from "ui/action-bar";
 import { isBlank } from "../lang-facade";
-import {Page} from "ui/page";
+import { Page } from "ui/page";
 import { View } from "ui/core/view";
-import { registerElement, ViewClassMeta, NgView } from "../element-registry";
+import { registerElement, ViewClassMeta, NgView, TEMPLATE } from "../element-registry";
 
 let actionBarMeta: ViewClassMeta = {
     skipAddToDom: true,
@@ -17,7 +17,7 @@ let actionBarMeta: ViewClassMeta = {
         } else if (child instanceof ActionItem) {
             bar.actionItems.addItem(childView);
             childView.parent = bar;
-        } else if (child.nodeName === "template") {
+        } else if (child.nodeName === TEMPLATE) {
             child.templateParent = parent;
         } else if (child.nodeName !== "#text" && child instanceof View) {
             bar.titleView = childView;
@@ -34,8 +34,8 @@ let actionBarMeta: ViewClassMeta = {
         } else if (child instanceof ActionItem) {
             bar.actionItems.removeItem(childView);
             childView.parent = null;
-        } else if (child.nodeName !== "template" && child instanceof View &&
-                bar.titleView && bar.titleView === childView) {
+        } else if (child.nodeName !== TEMPLATE && child instanceof View &&
+            bar.titleView && bar.titleView === childView) {
             bar.titleView = null;
         }
     },

--- a/nativescript-angular/element-registry.ts
+++ b/nativescript-angular/element-registry.ts
@@ -1,12 +1,14 @@
-import {View} from "ui/core/view";
+import { View } from "ui/core/view";
 
 export type ViewResolver = () => ViewClass;
 export type NgView = View & ViewExtensions;
+export const TEMPLATE = "template";
 
 export interface ViewClassMeta {
     skipAddToDom?: boolean;
     insertChild?: (parent: NgView, child: NgView, atIndex: number) => void;
     removeChild?: (parent: NgView, child: NgView) => void;
+    isTemplateAnchor?: boolean;
 }
 
 export interface ViewExtensions {
@@ -24,7 +26,7 @@ const defaultViewMeta: ViewClassMeta = {
     skipAddToDom: false,
 };
 
-const elementMap  = new Map<string, { resolver: ViewResolver, meta?: ViewClassMeta }>();
+const elementMap = new Map<string, { resolver: ViewResolver, meta?: ViewClassMeta }>();
 const camelCaseSplit = /([a-z0-9])([A-Z])/g;
 
 export function registerElement(
@@ -69,6 +71,10 @@ export function isKnownView(elementName: string): boolean {
         elementMap.has(elementName.toLowerCase());
 }
 
+// Empty view used for template anchors
+export class TemplateView extends View {
+}
+registerElement(TEMPLATE, () => TemplateView, { isTemplateAnchor: true });
 
 // Register default NativeScript components
 // Note: ActionBar related components are registerd together with action-bar directives.

--- a/ng-sample/app/app.ts
+++ b/ng-sample/app/app.ts
@@ -19,9 +19,9 @@ import { Page } from "ui/page";
 import { Color } from "color";
 
 import trace = require("trace");
-// trace.setCategories(rendererTraceCategory);
+trace.setCategories(rendererTraceCategory);
 // trace.setCategories(routerTraceCategory);
-trace.setCategories(listViewTraceCategory);
+// trace.setCategories(listViewTraceCategory);
 trace.enable();
 
 import { RendererTest } from './examples/renderer-test';
@@ -114,28 +114,29 @@ const customPageFactoryProvider = {
 
 platformNativeScriptDynamic().bootstrapModule(makeExampleModule(RendererTest));
 // platformNativeScriptDynamic(undefined, [customPageFactoryProvider]).bootstrapModule(makeExampleModule(RendererTest));
-//platformNativeScriptDynamic().bootstrapModule(makeExampleModule(TabViewTest));
-//platformNativeScriptDynamic().bootstrapModule(makeExampleModule(Benchmark));
-//platformNativeScriptDynamic().bootstrapModule(makeExampleModule(ListTest));
+// platformNativeScriptDynamic().bootstrapModule(makeExampleModule(TabViewTest));
+// platformNativeScriptDynamic().bootstrapModule(makeExampleModule(Benchmark));
+// platformNativeScriptDynamic().bootstrapModule(makeExampleModule(ListTest));
 // platformNativeScriptDynamic().bootstrapModule(makeExampleModule(ListTemplateSelectorTest));
-//platformNativeScriptDynamic().bootstrapModule(makeExampleModule(ListTestAsync));
-//platformNativeScriptDynamic().bootstrapModule(makeExampleModule(ImageTest));
+// platformNativeScriptDynamic().bootstrapModule(makeExampleModule(ListTestAsync));
+// platformNativeScriptDynamic().bootstrapModule(makeExampleModule(ImageTest));
 // platformNativeScriptDynamic().bootstrapModule(makeExampleModule(ModalTest));
-//platformNativeScriptDynamic().bootstrapModule(makeExampleModule(HttpTest));
-//platformNativeScriptDynamic().bootstrapModule(makeExampleModule(PlatfromDirectivesTest));
-//platformNativeScriptDynamic().bootstrapModule(makeExampleModule(ActionBarTest));
+// platformNativeScriptDynamic().bootstrapModule(makeExampleModule(HttpTest));
+// platformNativeScriptDynamic().bootstrapModule(makeExampleModule(PlatfromDirectivesTest));
+// platformNativeScriptDynamic().bootstrapModule(makeExampleModule(ActionBarTest));
 
-//new router
-//platformNativeScriptDynamic().bootstrapModule(makeExampleModule(RouterOutletAppComponent));
+// router
+// platformNativeScriptDynamic().bootstrapModule(makeExampleModule(RouterOutletAppComponent));
 // platformNativeScriptDynamic().bootstrapModule(makeExampleModule(PageRouterOutletAppComponent));
-//platformNativeScriptDynamic().bootstrapModule(makeExampleModule(PageRouterOutletNestedAppComponent));
-//platformNativeScriptDynamic().bootstrapModule(makeExampleModule(ClearHistoryAppComponent));
-//platformNativeScriptDynamic().bootstrapModule(makeExampleModule(LoginAppComponent));
-//animations
-//platformNativeScriptDynamic().bootstrapModule(makeExampleModule(AnimationStatesTest));
-//platformNativeScriptDynamic().bootstrapModule(makeExampleModule(AnimationNgClassTest));
-//platformNativeScriptDynamic().bootstrapModule(makeExampleModule(AnimationKeyframesTest));
-//platformNativeScriptDynamic().bootstrapModule(makeExampleModule(AnimationEnterLeaveTest));
+// platformNativeScriptDynamic().bootstrapModule(makeExampleModule(PageRouterOutletNestedAppComponent));
+// platformNativeScriptDynamic().bootstrapModule(makeExampleModule(ClearHistoryAppComponent));
+// platformNativeScriptDynamic().bootstrapModule(makeExampleModule(LoginAppComponent));
+
+// animations
+// platformNativeScriptDynamic().bootstrapModule(makeExampleModule(AnimationStatesTest));
+// platformNativeScriptDynamic().bootstrapModule(makeExampleModule(AnimationNgClassTest));
+// platformNativeScriptDynamic().bootstrapModule(makeExampleModule(AnimationKeyframesTest));
+// platformNativeScriptDynamic().bootstrapModule(makeExampleModule(AnimationEnterLeaveTest));
 
 //Livesync test
 var cachedUrl: string;

--- a/ng-sample/hooks/before-livesync/nativescript-angular-sync .js
+++ b/ng-sample/hooks/before-livesync/nativescript-angular-sync .js
@@ -1,1 +1,0 @@
-module.exports = require("nativescript-angular/hooks/before-livesync");


### PR DESCRIPTION
With angular `2.2.1` additional template anchors are created for components, which cause problems when added to content-view(ex. Page)