### PR TITLE
ListView using wrong template after navigation

### DIFF
--- a/nativescript-angular/directives/list-view-comp.ts
+++ b/nativescript-angular/directives/list-view-comp.ts
@@ -69,7 +69,9 @@ export class ListViewComponent implements DoCheck, OnDestroy, AfterContentInit {
 
     @Output() public setupItemView = new EventEmitter<SetupItemViewArgs>();
 
-    @ContentChild(TemplateRef) itemTemplate: TemplateRef<ListItemContext>;
+    @ContentChild(TemplateRef) itemTemplateQuery: TemplateRef<ListItemContext>;
+
+    itemTemplate: TemplateRef<ListItemContext>;
 
     @Input()
     get items() {
@@ -108,6 +110,10 @@ export class ListViewComponent implements DoCheck, OnDestroy, AfterContentInit {
     }
 
     private setItemTemplates() {
+        // The itemTemplateQuery may be changed after list items are added that contain <template> inside,
+        // so cache and use only the original template to avoid errors.
+        this.itemTemplate = this.itemTemplateQuery;
+
         if (this._templateMap) {
             listViewLog("Setting templates");
 


### PR DESCRIPTION
Fixes bug when ListView component starts using wrong template if there is a nested <template> inside its item-template.

Added a sample repro of the problem in the [test-app-ng](https://github.com/NativeScript/tests-app-ng/commit/603c30b94850610311ed9c7612115aa77ec739a5)
To reproduce:
1. Navigate to listViewExamples -> nestedTemplate
2. ListView is shown as expected.
3. Click navigate, then go back.
4. ListView items should be the same again.

Resolves #572

cc @SvetoslavTsenov 


