### PR TITLE
Call the runtime require function instead of the webpack's one in ns-module-factory-loader

### DIFF
--- a/nativescript-angular/router/ns-module-factory-loader.ts
+++ b/nativescript-angular/router/ns-module-factory-loader.ts
@@ -42,7 +42,7 @@ export class NSModuleFactoryLoader implements NgModuleFactoryLoader {
     private loadAndCompile(modulePath: string, exportName: string): Promise<NgModuleFactory<any>> {
         modulePath = getAbsolutePath(modulePath);
 
-        let loadedModule = require(modulePath)[exportName];
+        let loadedModule = global.require(modulePath)[exportName];
         checkNotEmpty(loadedModule, modulePath, exportName);
 
         return Promise.resolve(this.compiler.compileModuleAsync(loadedModule));


### PR DESCRIPTION
Since `ns-module-factory-loader` contains [dynamic require call](https://github.com/NativeScript/nativescript-angular/blob/master/nativescript-angular/router/ns-module-factory-loader.ts#L45), when it is webpacked, a [context module](https://webpack.github.io/docs/context.html#context-module) is generated for it. By default, when a module is dynamically required by a context module it must reside in the same directory as the context module in order to be resolved by the `webpack`'s require. This means that after [this change in the sdk examples](https://github.com/NativeScript/nativescript-sdk-examples-ng/commit/7feec82f8192b0de5704561686a535db90fb6598), the example app will crash with `Module not found` when a module that is not in the same directory as `ns-module-factory-loader.ts` is required.
This commit makes `ns-module-factory-loader` "webpackable" and "snapshotable" by replacing the  call to the webpack `require` function (`webpack` replaces all `require(..)` calls to `__webpack_require(..)` calls) to call to the runtime's `require` function.