### PR TITLE
fix(gitignore): Add editor files and folders to be excluded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,18 @@ ng-sample/app/nativescript-angular
 startup-test/platforms
 startup-test/lib
 startup-test/node_modules
+
+# IDEs and editors
+/.idea
+.project
+.classpath
+.c9/
+*.launch
+.settings/
+
+# IDE - VSCode
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json


### PR DESCRIPTION
Hi!
This PR adds more files and folders to exclude in the `gitignore`.
Mostly Webstorm like and Visual Code editors.

### Issue
There is not issue about that but I can create one and link it if you need me to.

### Add [tests](https://github.com/NativeScript/nativescript-angular/tests)
If not added, tell us why? No need to add tests as i didn't change the code.

Thanks!