### PR TITLE
chore(modules): Use fully-qualified imports for tns-core-modules

### DIFF
--- a/nativescript-angular/animation-driver.ts
+++ b/nativescript-angular/animation-driver.ts
@@ -1,7 +1,7 @@
 import { AnimationPlayer } from "@angular/core";
 import { AnimationStyles, AnimationKeyframe } from "./private_import_core";
 import { NativeScriptAnimationPlayer } from "./animation-player";
-import { View } from "ui/core/view";
+import { View } from "tns-core-modules/ui/core/view";
 
 export abstract class AnimationDriver {
     abstract animate(

--- a/nativescript-angular/animation-player.ts
+++ b/nativescript-angular/animation-player.ts
@@ -5,11 +5,11 @@ import {
     KeyframeAnimationInfo,
     KeyframeInfo,
     KeyframeDeclaration
-} from "ui/animation/keyframe-animation";
-import { View } from "ui/core/view";
-import { AnimationCurve } from "ui/enums";
-import { isString } from "utils/types";
-import { CssAnimationProperty } from "ui/core/properties";
+} from "tns-core-modules/ui/animation/keyframe-animation";
+import { View } from "tns-core-modules/ui/core/view";
+import { AnimationCurve } from "tns-core-modules/ui/enums";
+import { isString } from "tns-core-modules/utils/types";
+import { CssAnimationProperty } from "tns-core-modules/ui/core/properties";
 
 export class NativeScriptAnimationPlayer implements AnimationPlayer {
 

--- a/nativescript-angular/common/detached-loader.ts
+++ b/nativescript-angular/common/detached-loader.ts
@@ -2,7 +2,7 @@ import {
     ComponentRef, ComponentFactory, ViewContainerRef,
     Component, Type, ComponentFactoryResolver, ChangeDetectorRef
 } from "@angular/core";
-import { write } from "trace";
+import { write } from "tns-core-modules/trace";
 
 export const CATEGORY = "detached-loader";
 function log(message: string) {

--- a/nativescript-angular/directives/action-bar.ts
+++ b/nativescript-angular/directives/action-bar.ts
@@ -1,8 +1,8 @@
 import { Directive, Component, ElementRef, Optional, OnDestroy } from "@angular/core";
-import { ActionItem, ActionBar, NavigationButton } from "ui/action-bar";
+import { ActionItem, ActionBar, NavigationButton } from "tns-core-modules/ui/action-bar";
 import { isBlank } from "../lang-facade";
-import { Page } from "ui/page";
-import { View } from "ui/core/view";
+import { Page } from "tns-core-modules/ui/page";
+import { View } from "tns-core-modules/ui/core/view";
 import { registerElement, ViewClassMeta, NgView, TEMPLATE } from "../element-registry";
 
 let actionBarMeta: ViewClassMeta = {

--- a/nativescript-angular/directives/dialogs.ts
+++ b/nativescript-angular/directives/dialogs.ts
@@ -2,8 +2,8 @@ import {
     ReflectiveInjector, ComponentFactoryResolver, ViewContainerRef,
     Type, Injectable, ComponentRef, Directive
 } from "@angular/core";
-import { Page } from "ui/page";
-import { View } from "ui/core/view";
+import { Page } from "tns-core-modules/ui/page";
+import { View } from "tns-core-modules/ui/core/view";
 import { DetachedLoader } from "../common/detached-loader";
 import { PageFactory, PAGE_FACTORY } from "../platform-providers";
 

--- a/nativescript-angular/directives/list-view-comp.ts
+++ b/nativescript-angular/directives/list-view-comp.ts
@@ -21,10 +21,10 @@ import {
 } from "@angular/core";
 import { isBlank } from "../lang-facade";
 import { isListLikeIterable } from "../collection-facade";
-import { ListView } from "ui/list-view";
-import { View, KeyedTemplate } from "ui/core/view";
-import { ObservableArray } from "data/observable-array";
-import { LayoutBase } from "ui/layouts/layout-base";
+import { ListView } from "tns-core-modules/ui/list-view";
+import { View, KeyedTemplate } from "tns-core-modules/ui/core/view";
+import { ObservableArray } from "tns-core-modules/data/observable-array";
+import { LayoutBase } from "tns-core-modules/ui/layouts/layout-base";
 import { listViewLog } from "../trace";
 
 const NG_VIEW = "_ngViewRef";

--- a/nativescript-angular/directives/platform-filters.ts
+++ b/nativescript-angular/directives/platform-filters.ts
@@ -1,5 +1,5 @@
 import { Component, Inject } from "@angular/core";
-import { Device, platformNames } from "platform";
+import { Device, platformNames } from "tns-core-modules/platform";
 import { DEVICE } from "../platform-providers";
 
 @Component({

--- a/nativescript-angular/directives/tab-view.ts
+++ b/nativescript-angular/directives/tab-view.ts
@@ -1,5 +1,5 @@
 import { ElementRef, Directive, Input, TemplateRef, ViewContainerRef, OnInit, AfterViewInit } from "@angular/core";
-import { TabView, TabViewItem } from "ui/tab-view";
+import { TabView, TabViewItem } from "tns-core-modules/ui/tab-view";
 import { convertToInt } from "../common/utils";
 import { rendererLog } from "../trace";
 import { isBlank } from "../lang-facade";

--- a/nativescript-angular/element-registry.ts
+++ b/nativescript-angular/element-registry.ts
@@ -1,4 +1,4 @@
-import { View } from "ui/core/view";
+import { View } from "tns-core-modules/ui/core/view";
 
 export type ViewResolver = () => ViewClass;
 export type NgView = View & ViewExtensions;
@@ -78,42 +78,42 @@ registerElement(TEMPLATE, () => TemplateView, { isTemplateAnchor: true });
 
 // Register default NativeScript components
 // Note: ActionBar related components are registerd together with action-bar directives.
-registerElement("AbsoluteLayout", () => require("ui/layouts/absolute-layout").AbsoluteLayout);
-registerElement("ActivityIndicator", () => require("ui/activity-indicator").ActivityIndicator);
-registerElement("Border", () => require("ui/border").Border);
-registerElement("Button", () => require("ui/button").Button);
-registerElement("ContentView", () => require("ui/content-view").ContentView);
-registerElement("DatePicker", () => require("ui/date-picker").DatePicker);
-registerElement("DockLayout", () => require("ui/layouts/dock-layout").DockLayout);
-registerElement("GridLayout", () => require("ui/layouts/grid-layout").GridLayout);
-registerElement("HtmlView", () => require("ui/html-view").HtmlView);
-registerElement("Image", () => require("ui/image").Image);
+registerElement("AbsoluteLayout", () => require("tns-core-modules/ui/layouts/absolute-layout").AbsoluteLayout);
+registerElement("ActivityIndicator", () => require("tns-core-modules/ui/activity-indicator").ActivityIndicator);
+registerElement("Border", () => require("tns-core-modules/ui/border").Border);
+registerElement("Button", () => require("tns-core-modules/ui/button").Button);
+registerElement("ContentView", () => require("tns-core-modules/ui/content-view").ContentView);
+registerElement("DatePicker", () => require("tns-core-modules/ui/date-picker").DatePicker);
+registerElement("DockLayout", () => require("tns-core-modules/ui/layouts/dock-layout").DockLayout);
+registerElement("GridLayout", () => require("tns-core-modules/ui/layouts/grid-layout").GridLayout);
+registerElement("HtmlView", () => require("tns-core-modules/ui/html-view").HtmlView);
+registerElement("Image", () => require("tns-core-modules/ui/image").Image);
 // Parse5 changes <Image> tags to <img>. WTF!
-registerElement("img", () => require("ui/image").Image);
-registerElement("Label", () => require("ui/label").Label);
-registerElement("ListPicker", () => require("ui/list-picker").ListPicker);
-registerElement("ListView", () => require("ui/list-view").ListView);
-registerElement("Page", () => require("ui/page").Page);
-registerElement("Placeholder", () => require("ui/placeholder").Placeholder);
-registerElement("Progress", () => require("ui/progress").Progress);
-registerElement("ProxyViewContainer", () => require("ui/proxy-view-container").ProxyViewContainer);
-registerElement("Repeater", () => require("ui/repeater").Repeater);
-registerElement("ScrollView", () => require("ui/scroll-view").ScrollView);
-registerElement("SearchBar", () => require("ui/search-bar").SearchBar);
-registerElement("SegmentedBar", () => require("ui/segmented-bar").SegmentedBar);
-registerElement("SegmentedBarItem", () => require("ui/segmented-bar").SegmentedBarItem);
-registerElement("Slider", () => require("ui/slider").Slider);
-registerElement("StackLayout", () => require("ui/layouts/stack-layout").StackLayout);
-registerElement("FlexboxLayout", () => require("ui/layouts/flexbox-layout").FlexboxLayout);
-registerElement("Switch", () => require("ui/switch").Switch);
-registerElement("TabView", () => require("ui/tab-view").TabView);
-registerElement("TextField", () => require("ui/text-field").TextField);
-registerElement("TextView", () => require("ui/text-view").TextView);
-registerElement("TimePicker", () => require("ui/time-picker").TimePicker);
-registerElement("WebView", () => require("ui/web-view").WebView);
-registerElement("WrapLayout", () => require("ui/layouts/wrap-layout").WrapLayout);
-registerElement("FormattedString", () => require("text/formatted-string").FormattedString);
-registerElement("Span", () => require("text/span").Span);
+registerElement("img", () => require("tns-core-modules/ui/image").Image);
+registerElement("Label", () => require("tns-core-modules/ui/label").Label);
+registerElement("ListPicker", () => require("tns-core-modules/ui/list-picker").ListPicker);
+registerElement("ListView", () => require("tns-core-modules/ui/list-view").ListView);
+registerElement("Page", () => require("tns-core-modules/ui/page").Page);
+registerElement("Placeholder", () => require("tns-core-modules/ui/placeholder").Placeholder);
+registerElement("Progress", () => require("tns-core-modules/ui/progress").Progress);
+registerElement("ProxyViewContainer", () => require("tns-core-modules/ui/proxy-view-container").ProxyViewContainer);
+registerElement("Repeater", () => require("tns-core-modules/ui/repeater").Repeater);
+registerElement("ScrollView", () => require("tns-core-modules/ui/scroll-view").ScrollView);
+registerElement("SearchBar", () => require("tns-core-modules/ui/search-bar").SearchBar);
+registerElement("SegmentedBar", () => require("tns-core-modules/ui/segmented-bar").SegmentedBar);
+registerElement("SegmentedBarItem", () => require("tns-core-modules/ui/segmented-bar").SegmentedBarItem);
+registerElement("Slider", () => require("tns-core-modules/ui/slider").Slider);
+registerElement("StackLayout", () => require("tns-core-modules/ui/layouts/stack-layout").StackLayout);
+registerElement("FlexboxLayout", () => require("tns-core-modules/ui/layouts/flexbox-layout").FlexboxLayout);
+registerElement("Switch", () => require("tns-core-modules/ui/switch").Switch);
+registerElement("TabView", () => require("tns-core-modules/ui/tab-view").TabView);
+registerElement("TextField", () => require("tns-core-modules/ui/text-field").TextField);
+registerElement("TextView", () => require("tns-core-modules/ui/text-view").TextView);
+registerElement("TimePicker", () => require("tns-core-modules/ui/time-picker").TimePicker);
+registerElement("WebView", () => require("tns-core-modules/ui/web-view").WebView);
+registerElement("WrapLayout", () => require("tns-core-modules/ui/layouts/wrap-layout").WrapLayout);
+registerElement("FormattedString", () => require("tns-core-modules/text/formatted-string").FormattedString);
+registerElement("Span", () => require("tns-core-modules/text/span").Span);
 
-registerElement("DetachedContainer", () => require("ui/proxy-view-container").ProxyViewContainer,
+registerElement("DetachedContainer", () => require("tns-core-modules/ui/proxy-view-container").ProxyViewContainer,
     { skipAddToDom: true });

--- a/nativescript-angular/file-system/ns-file-system.ts
+++ b/nativescript-angular/file-system/ns-file-system.ts
@@ -1,5 +1,5 @@
 import { Injectable } from "@angular/core";
-import { knownFolders, Folder } from "file-system";
+import { knownFolders, Folder } from "tns-core-modules/file-system";
 
 // Allows greater flexibility with `file-system` and Angular
 // Also provides a way for `file-system` to be mocked for testing

--- a/nativescript-angular/platform-common.ts
+++ b/nativescript-angular/platform-common.ts
@@ -28,10 +28,10 @@ if ((<any>global).___TS_UNUSED) {
 import { rendererLog, rendererError } from "./trace";
 import { PAGE_FACTORY, PageFactory, defaultPageFactoryProvider } from "./platform-providers";
 
-import { start, setCssFileName } from "application";
-import { topmost, NavigationEntry } from "ui/frame";
-import { Page } from "ui/page";
-import { TextView } from "ui/text-view";
+import { start, setCssFileName } from "tns-core-modules/application";
+import { topmost, NavigationEntry } from "tns-core-modules/ui/frame";
+import { Page } from "tns-core-modules/ui/page";
+import { TextView } from "tns-core-modules/ui/text-view";
 
 import "nativescript-intl";
 

--- a/nativescript-angular/platform-providers.ts
+++ b/nativescript-angular/platform-providers.ts
@@ -1,8 +1,8 @@
-import { topmost, Frame } from "ui/frame";
-import { Page } from "ui/page";
+import { topmost, Frame } from "tns-core-modules/ui/frame";
+import { Page } from "tns-core-modules/ui/page";
 import { OpaqueToken } from "@angular/core";
-import { device, Device } from "platform";
-import * as platform from "platform";
+import { device, Device } from "tns-core-modules/platform";
+import * as platform from "tns-core-modules/platform";
 
 export const APP_ROOT_VIEW = new OpaqueToken("App Root View");
 export const DEVICE = new OpaqueToken("platfrom device");

--- a/nativescript-angular/renderer.ts
+++ b/nativescript-angular/renderer.ts
@@ -5,15 +5,15 @@ import {
 import { AnimationStyles, AnimationKeyframe } from "./private_import_core";
 import { APP_ROOT_VIEW, DEVICE } from "./platform-providers";
 import { isBlank } from "./lang-facade";
-import { View } from "ui/core/view";
-import { addCss } from "application";
-import { topmost } from "ui/frame";
-import { Page } from "ui/page";
+import { View } from "tns-core-modules/ui/core/view";
+import { addCss } from "tns-core-modules/application";
+import { topmost } from "tns-core-modules/ui/frame";
+import { Page } from "tns-core-modules/ui/page";
 import { ViewUtil } from "./view-util";
 import { NgView } from "./element-registry";
 import { rendererLog as traceLog } from "./trace";
-import { escapeRegexSymbols } from "utils/utils";
-import { Device } from "platform";
+import { escapeRegexSymbols } from "tns-core-modules/utils/utils";
+import { Device } from "tns-core-modules/platform";
 
 import { NativeScriptAnimationDriver } from "./animation-driver";
 

--- a/nativescript-angular/resource-loader.ts
+++ b/nativescript-angular/resource-loader.ts
@@ -1,4 +1,4 @@
-import { path, knownFolders, File } from "file-system";
+import { path, knownFolders, File } from "tns-core-modules/file-system";
 import { ResourceLoader } from "@angular/compiler";
 
 export class FileSystemResourceLoader extends ResourceLoader {

--- a/nativescript-angular/router.ts
+++ b/nativescript-angular/router.ts
@@ -8,7 +8,7 @@ import {
 } from "@angular/core";
 import { RouterModule, Routes, ExtraOptions } from "@angular/router";
 import { LocationStrategy, PlatformLocation } from "@angular/common";
-import { Frame } from "ui/frame";
+import { Frame } from "tns-core-modules/ui/frame";
 import { NSRouterLink } from "./router/ns-router-link";
 import { NSRouterLinkActive } from "./router/ns-router-link-active";
 import { PageRouterOutlet } from "./router/page-router-outlet";

--- a/nativescript-angular/router/ns-location-strategy.ts
+++ b/nativescript-angular/router/ns-location-strategy.ts
@@ -1,7 +1,7 @@
 import { Injectable } from "@angular/core";
 import { LocationStrategy } from "@angular/common";
 import { routerLog } from "../trace";
-import { Frame, NavigationTransition } from "ui/frame";
+import { Frame, NavigationTransition } from "tns-core-modules/ui/frame";
 import { isPresent } from "../lang-facade";
 
 export interface NavigationOptions {

--- a/nativescript-angular/router/ns-module-factory-loader.ts
+++ b/nativescript-angular/router/ns-module-factory-loader.ts
@@ -6,7 +6,7 @@ import {
     SystemJsNgModuleLoader,
 } from "@angular/core";
 
-import { path, knownFolders } from "file-system";
+import { path, knownFolders } from "tns-core-modules/file-system";
 
 const SEPARATOR = "#";
 

--- a/nativescript-angular/router/ns-router-link.ts
+++ b/nativescript-angular/router/ns-router-link.ts
@@ -5,8 +5,8 @@ import { routerLog } from "../trace";
 import { PageRoute } from "./page-router-outlet";
 import { RouterExtensions } from "./router-extensions";
 import { NavigationOptions } from "./ns-location-strategy";
-import { NavigationTransition } from "ui/frame";
-import { isString } from "utils/types";
+import { NavigationTransition } from "tns-core-modules/ui/frame";
+import { isString } from "tns-core-modules/utils/types";
 
 /**
  * The nsRouterLink directive lets you link to specific parts of your app.

--- a/nativescript-angular/router/page-router-outlet.ts
+++ b/nativescript-angular/router/page-router-outlet.ts
@@ -7,12 +7,12 @@ import { isPresent } from "../lang-facade";
 import { RouterOutletMap, ActivatedRoute, PRIMARY_OUTLET } from "@angular/router";
 import { NSLocationStrategy } from "./ns-location-strategy";
 import { DEVICE, PAGE_FACTORY, PageFactory } from "../platform-providers";
-import { Device } from "platform";
+import { Device } from "tns-core-modules/platform";
 import { routerLog } from "../trace";
 import { DetachedLoader } from "../common/detached-loader";
 import { ViewUtil } from "../view-util";
-import { Frame } from "ui/frame";
-import { Page, NavigatedData } from "ui/page";
+import { Frame } from "tns-core-modules/ui/frame";
+import { Page, NavigatedData } from "tns-core-modules/ui/page";
 import { BehaviorSubject } from "rxjs/BehaviorSubject";
 
 interface CacheItem {

--- a/nativescript-angular/router/router-extensions.ts
+++ b/nativescript-angular/router/router-extensions.ts
@@ -1,7 +1,7 @@
 import { Injectable } from "@angular/core";
 import { Router, UrlTree, NavigationExtras } from "@angular/router";
 import { NSLocationStrategy, NavigationOptions } from "./ns-location-strategy";
-import { Frame } from "ui/frame";
+import { Frame } from "tns-core-modules/ui/frame";
 
 export type ExtendedNavigationExtras = NavigationExtras & NavigationOptions;
 

--- a/nativescript-angular/trace.ts
+++ b/nativescript-angular/trace.ts
@@ -1,4 +1,4 @@
-import { write, categories, messageType } from "trace";
+import { write, categories, messageType } from "tns-core-modules/trace";
 
 export const rendererTraceCategory = "ns-renderer";
 export const routerTraceCategory = "ns-router";

--- a/nativescript-angular/tsconfig.json
+++ b/nativescript-angular/tsconfig.json
@@ -17,14 +17,7 @@
     "lib": [
         "dom",
         "es6"
-    ],
-    "baseUrl": ".",
-    "paths": {
-      "*": [
-        "./node_modules/tns-core-modules/*",
-        "./node_modules/*"
-      ]
-    }
+    ]
   },
   "angularCompilerOptions": {
     "genDir": ".",

--- a/nativescript-angular/value-accessors/checked-value-accessor.ts
+++ b/nativescript-angular/value-accessors/checked-value-accessor.ts
@@ -2,7 +2,7 @@ import { Directive, ElementRef, forwardRef, HostListener } from "@angular/core";
 import { NG_VALUE_ACCESSOR } from "@angular/forms";
 import { isBlank } from "../lang-facade";
 import { BaseValueAccessor } from "./base-value-accessor";
-import { Switch } from "ui/switch";
+import { Switch } from "tns-core-modules/ui/switch";
 
 const CHECKED_VALUE_ACCESSOR = {provide: NG_VALUE_ACCESSOR,
     useExisting: forwardRef(() => CheckedValueAccessor), multi: true};

--- a/nativescript-angular/value-accessors/date-value-accessor.ts
+++ b/nativescript-angular/value-accessors/date-value-accessor.ts
@@ -2,7 +2,7 @@ import { Directive, ElementRef, forwardRef, HostListener } from "@angular/core";
 import { NG_VALUE_ACCESSOR } from "@angular/forms";
 import { isBlank, isDate } from "../lang-facade";
 import { BaseValueAccessor } from "./base-value-accessor";
-import { DatePicker } from "ui/date-picker";
+import { DatePicker } from "tns-core-modules/ui/date-picker";
 
 const DATE_VALUE_ACCESSOR = {provide: NG_VALUE_ACCESSOR,
     useExisting: forwardRef(() => DateValueAccessor), multi: true};

--- a/nativescript-angular/value-accessors/number-value-accessor.ts
+++ b/nativescript-angular/value-accessors/number-value-accessor.ts
@@ -2,7 +2,7 @@ import { Directive, ElementRef, forwardRef, HostListener } from "@angular/core";
 import { NG_VALUE_ACCESSOR } from "@angular/forms";
 import { isBlank, isNumber } from "../lang-facade";
 import { BaseValueAccessor } from "./base-value-accessor";
-import { Slider } from "ui/slider";
+import { Slider } from "tns-core-modules/ui/slider";
 
 const NUMBER_VALUE_ACCESSOR = {provide: NG_VALUE_ACCESSOR,
     useExisting: forwardRef(() => NumberValueAccessor), multi: true};

--- a/nativescript-angular/value-accessors/selectedIndex-value-accessor.ts
+++ b/nativescript-angular/value-accessors/selectedIndex-value-accessor.ts
@@ -1,7 +1,7 @@
 import { Directive, ElementRef, forwardRef, AfterViewInit, HostListener } from "@angular/core";
 import { NG_VALUE_ACCESSOR } from "@angular/forms";
 import { BaseValueAccessor } from "./base-value-accessor";
-import { View } from "ui/core/view";
+import { View } from "tns-core-modules/ui/core/view";
 import { convertToInt } from "../common/utils";
 
 const SELECTED_INDEX_VALUE_ACCESSOR = {provide: NG_VALUE_ACCESSOR,

--- a/nativescript-angular/value-accessors/text-value-accessor.ts
+++ b/nativescript-angular/value-accessors/text-value-accessor.ts
@@ -2,7 +2,7 @@ import { Directive, ElementRef, forwardRef, HostListener } from "@angular/core";
 import { NG_VALUE_ACCESSOR } from "@angular/forms";
 import { isBlank } from "../lang-facade";
 import { BaseValueAccessor } from "./base-value-accessor";
-import { View } from "ui/core/view";
+import { View } from "tns-core-modules/ui/core/view";
 
 const TEXT_VALUE_ACCESSOR = {provide: NG_VALUE_ACCESSOR,
     useExisting: forwardRef(() => TextValueAccessor), multi: true};

--- a/nativescript-angular/value-accessors/time-value-accessor.ts
+++ b/nativescript-angular/value-accessors/time-value-accessor.ts
@@ -2,7 +2,7 @@ import { Directive, ElementRef, forwardRef, HostListener } from "@angular/core";
 import { NG_VALUE_ACCESSOR } from "@angular/forms";
 import { isBlank, isDate } from "../lang-facade";
 import { BaseValueAccessor } from "./base-value-accessor";
-import { TimePicker } from "ui/time-picker";
+import { TimePicker } from "tns-core-modules/ui/time-picker";
 
 const TIME_VALUE_ACCESSOR = {provide: NG_VALUE_ACCESSOR,
     useExisting: forwardRef(() => TimeValueAccessor), multi: true};

--- a/nativescript-angular/view-util.ts
+++ b/nativescript-angular/view-util.ts
@@ -1,8 +1,8 @@
-import { isDefined } from "utils/types";
-import { View, unsetValue } from "ui/core/view";
-import { Placeholder } from "ui/placeholder";
-import { ContentView } from "ui/content-view";
-import { LayoutBase } from "ui/layouts/layout-base";
+import { isDefined } from "tns-core-modules/utils/types";
+import { View, unsetValue } from "tns-core-modules/ui/core/view";
+import { Placeholder } from "tns-core-modules/ui/placeholder";
+import { ContentView } from "tns-core-modules/ui/content-view";
+import { LayoutBase } from "tns-core-modules/ui/layouts/layout-base";
 import {
     ViewClass,
     getViewClass,
@@ -12,7 +12,7 @@ import {
     NgView,
     TEMPLATE
 } from "./element-registry";
-import { platformNames, Device } from "platform";
+import { platformNames, Device } from "tns-core-modules/platform";
 import { rendererLog as traceLog } from "./trace";
 
 const IOS_PREFX: string = ":ios:";


### PR DESCRIPTION
Needed for AoT support when using TypeScript 2.2.

Merge after NativeScript/NativeScript#3773.