### PR TITLE
fix(action-bar): Don't remove action items twice.

### DIFF
--- a/nativescript-angular/directives/action-bar.ts
+++ b/nativescript-angular/directives/action-bar.ts
@@ -83,7 +83,9 @@ export class ActionBarScope { // tslint:disable-line:component-class-suffix
     }
 
     public onActionDestroy(item: ActionItemDirective) {
-        this.page.actionBar.actionItems.removeItem(item.element.nativeElement);
+        if (item.element.nativeElement.actionBar) {
+            this.page.actionBar.actionItems.removeItem(item.element.nativeElement);
+        }
     }
 }
 


### PR DESCRIPTION
tns-core-modules@3.0.0 turned action items into views and they
can get removed as a part of the view detach process -- think
*ngIf templates.

The file contained a bunch of DOS line endings, so I fixed it too. The actual change is in the ActionItem ngOnDestroy implementation:

```TypeScript
public onActionDestroy(item: ActionItemDirective) {
    if (item.element.nativeElement.actionBar) {
        this.page.actionBar.actionItems.removeItem(item.element.nativeElement);
    }
}
```