### PR TITLE
refactor: stop exporting NativeScriptModule from platform

### DIFF
--- a/nativescript-angular/platform.ts
+++ b/nativescript-angular/platform.ts
@@ -33,8 +33,6 @@ import "./dom-adapter";
 import { NativeScriptElementSchemaRegistry } from "./schema-registry";
 import { FileSystemResourceLoader } from "./resource-loader";
 
-export { NativeScriptModule } from "./nativescript.module";
-
 export const NS_COMPILER_PROVIDERS = [
     COMPILER_PROVIDERS,
     {

--- a/tests/app/lazy-loaded.module.ts
+++ b/tests/app/lazy-loaded.module.ts
@@ -1,5 +1,5 @@
 import { NgModule } from '@angular/core';
-import { NativeScriptModule } from "nativescript-angular";
+import { NativeScriptModule } from "nativescript-angular/nativescript.module";
 import { NativeScriptRouterModule } from "nativescript-angular/router";
 
 import { SecondComponent } from './second.component';

--- a/tests/app/main.ts
+++ b/tests/app/main.ts
@@ -1,5 +1,6 @@
 // "nativescript-angular/platform" import should be first in order to load some required settings (like globals and reflect-metadata)
-import { NativeScriptModule, platformNativeScriptDynamic } from "nativescript-angular/platform";
+import { NativeScriptModule } from "nativescript-angular/nativescript.module";
+import { platformNativeScriptDynamic } from "nativescript-angular/platform";
 import { NativeScriptRouterModule, NSModuleFactoryLoader } from "nativescript-angular/router";
 import { NativeScriptFormsModule } from "nativescript-angular/forms";
 import { AppComponent } from "./app.component";

--- a/tests/app/snippets/navigation/page-outlet.ts
+++ b/tests/app/snippets/navigation/page-outlet.ts
@@ -2,7 +2,8 @@ import { TestApp, registerTestApp } from "../../tests/test-app";
 import { ApplicationRef } from '@angular/core';
 import { Router, NavigationStart, NavigationEnd } from "@angular/router";
 // >> page-outlet-example
-import { platformNativeScriptDynamic, NativeScriptModule } from "nativescript-angular/platform";
+import { platformNativeScriptDynamic } from "nativescript-angular/platform";
+import { NativeScriptModule } from "nativescript-angular/nativescript.module";
 import { Component, NgModule } from '@angular/core';
 import { NativeScriptRouterModule } from "nativescript-angular/router";
 import { routes } from "./app.routes";

--- a/tests/app/tests/test-app.ts
+++ b/tests/app/tests/test-app.ts
@@ -1,4 +1,5 @@
-import { NativeScriptModule, platformNativeScriptDynamic } from "nativescript-angular/platform";
+import { platformNativeScriptDynamic } from "nativescript-angular/platform";
+import { NativeScriptModule } from "nativescript-angular/nativescript.module";
 import { NativeScriptRouterModule } from "nativescript-angular/router";
 import {
     Type, Component, ComponentRef,


### PR DESCRIPTION
Importing NativeScriptModule from "nativescript-angular/platform" leads to
including @angular/compiler in the bundle when doing AoT compilation
with webpack. Import from "nativescript-angular/nativescript.module"
should be used instead.

BREAKING CHANGE: User applications cannot import NativeScriptModule from
"nativescript-angular/platform" anymore.
Migration:
Before:
```
import { NativeScriptModule } from "nativescript-angular/platform";
```
After
```
import { NativeScriptModule } from
"nativescript-angular/nativescript.module";
```