### PR TITLE
Init Angular on Page.navigatingTo

### DIFF
--- a/nativescript-angular/renderer.ts
+++ b/nativescript-angular/renderer.ts
@@ -14,6 +14,7 @@ import { NgView } from "./element-registry";
 import { rendererLog as traceLog } from "./trace";
 import { escapeRegexSymbols } from "tns-core-modules/utils/utils";
 import { Device } from "tns-core-modules/platform";
+import { NativeScriptPlatformRef } from "./platform-common";
 
 import { NativeScriptAnimationDriver } from "./animation-driver";
 
@@ -46,7 +47,7 @@ export class NativeScriptRootRenderer implements RootRenderer {
 
     public get rootView(): View {
         if (!this._rootView) {
-            this._rootView = topmost().currentPage;
+            this._rootView = NativeScriptPlatformRef.rootPage || topmost().currentPage;
         }
         return this._rootView;
     }

--- a/ng-sample/app/app.ts
+++ b/ng-sample/app/app.ts
@@ -6,7 +6,8 @@
 //profiling.start("application-start");
 
 // "nativescript-angular/application" import should be first in order to load some required settings (like globals and reflect-metadata)
-import { NativeScriptModule, platformNativeScriptDynamic } from "nativescript-angular/platform";
+import { NativeScriptModule } from "nativescript-angular/nativescript.module";
+import { platformNativeScriptDynamic } from "nativescript-angular/platform";
 import { onAfterLivesync, onBeforeLivesync } from "nativescript-angular/platform-common";
 import { NgModule } from "@angular/core";
 import { Router } from "@angular/router";


### PR DESCRIPTION
...instead of `loaded`. Avoid a brief flash of a blank page on slower devices.

Fixes #620 