### PR TITLE
fix(platform-providers): Remove a circular import.

### DIFF
--- a/nativescript-angular/platform-common.ts
+++ b/nativescript-angular/platform-common.ts
@@ -26,7 +26,7 @@ if ((<any>global).___TS_UNUSED) {
 }
 
 import { rendererLog, rendererError } from "./trace";
-import { PAGE_FACTORY, PageFactory, defaultPageFactoryProvider } from "./platform-providers";
+import { PAGE_FACTORY, PageFactory, defaultPageFactoryProvider, setRootPage } from "./platform-providers";
 
 import { start, setCssFileName } from "tns-core-modules/application";
 import { topmost, NavigationEntry } from "tns-core-modules/ui/frame";
@@ -61,18 +61,9 @@ export const COMMON_PROVIDERS = [
 
 export class NativeScriptPlatformRef extends PlatformRef {
     private _bootstrapper: BootstrapperAction;
-    private static _rootPageRef: WeakRef<Page>;
 
     constructor(private platform: PlatformRef, private appOptions?: AppOptions) {
         super();
-    }
-
-    static set rootPage(page: Page) {
-        NativeScriptPlatformRef._rootPageRef = new WeakRef(page);
-    }
-
-    static get rootPage(): Page {
-        return NativeScriptPlatformRef._rootPageRef.get();
     }
 
     bootstrapModuleFactory<M>(moduleFactory: NgModuleFactory<M>): Promise<NgModuleRef<M>> {
@@ -158,7 +149,7 @@ export class NativeScriptPlatformRef extends PlatformRef {
         const navEntry: NavigationEntry = {
             create: (): Page => {
                 let page = pageFactory({ isBootstrap: true, isLivesync });
-                NativeScriptPlatformRef.rootPage = page;
+                setRootPage(page);
                 if (this.appOptions) {
                     page.actionBarHidden = this.appOptions.startPageActionBarHidden;
                 }

--- a/nativescript-angular/platform-providers.ts
+++ b/nativescript-angular/platform-providers.ts
@@ -15,14 +15,20 @@ if ((<any>global).___TS_UNUSED) {
     })();
 }
 
+let _rootPageRef: WeakRef<Page>;
+
+export function setRootPage(page: Page): void {
+    _rootPageRef = new WeakRef(page);
+}
+
+export function getRootPage(): Page {
+    return _rootPageRef && _rootPageRef.get();
+}
+
 // Use an exported function to make the AoT compiler happy.
 export function getDefaultPage(): Page {
     const frame = topmost();
-    if (frame) {
-        return frame.currentPage;
-    } else {
-        return null;
-    }
+    return getRootPage() || (frame && frame.currentPage);
 }
 
 export const defaultPageProvider = { provide: Page, useFactory: getDefaultPage };

--- a/nativescript-angular/renderer.ts
+++ b/nativescript-angular/renderer.ts
@@ -14,7 +14,7 @@ import { NgView } from "./element-registry";
 import { rendererLog as traceLog } from "./trace";
 import { escapeRegexSymbols } from "tns-core-modules/utils/utils";
 import { Device } from "tns-core-modules/platform";
-import { NativeScriptPlatformRef } from "./platform-common";
+import { getRootPage } from "./platform-providers";
 
 import { NativeScriptAnimationDriver } from "./animation-driver";
 
@@ -47,7 +47,7 @@ export class NativeScriptRootRenderer implements RootRenderer {
 
     public get rootView(): View {
         if (!this._rootView) {
-            this._rootView = NativeScriptPlatformRef.rootPage || topmost().currentPage;
+            this._rootView = getRootPage() || topmost().currentPage;
         }
         return this._rootView;
     }


### PR DESCRIPTION
Root page provider not crashing anymore.