### PR TITLE
fix(list-view): Revert onunload ng view destroy

### DIFF
--- a/nativescript-angular/directives/list-view-comp.ts
+++ b/nativescript-angular/directives/list-view-comp.ts
@@ -243,10 +243,6 @@ export type RootLocator = (nodes: Array<any>, nestLevel: number) => View;
 
 export function getItemViewRoot(viewRef: ComponentView, rootLocator: RootLocator = getSingleViewRecursive): View {
     const rootView = rootLocator(viewRef.rootNodes, 0);
-    rootView.on("unloaded", () => {
-        viewRef.destroy();
-        delete rootView[NG_VIEW];
-    });
     return rootView;
 }
 

--- a/tests/app/tests/list-view-tests.ts
+++ b/tests/app/tests/list-view-tests.ts
@@ -121,19 +121,3 @@ describe("ListView-tests", () => {
             .catch(done);
     });
 });
-
-describe("ListView item templates", () => {
-    it("destroy child ng views on unload", () => {
-        const childRoot = new ProxyViewContainer();
-        let viewDestroyed = false;
-        const view: ComponentView = {
-            rootNodes: [],
-            destroy: () => {
-                viewDestroyed = true;
-            }
-        };
-        const itemRoot = getItemViewRoot(view, (_rootNodes, _level) => childRoot);
-        itemRoot.notify({eventName: "unloaded", object: itemRoot});
-        assert.isTrue(viewDestroyed, "ng view not destroyed");
-    });
-});


### PR DESCRIPTION
The fix was not taking into account that view were being recycled
and was causing crashes due to prematurely destroying item views.

Reverts #703 
Related to #656 