### PR TITLE
FIX: ListView recycling for wrapped views

### DIFF
--- a/nativescript-angular/trace.ts
+++ b/nativescript-angular/trace.ts
@@ -23,3 +23,7 @@ export function styleError(message: string): void {
 export function listViewLog(message: string): void {
     write(message, listViewTraceCategory);
 }
+
+export function listViewError(message: string): void {
+    write(message, listViewTraceCategory, messageType.error);
+}


### PR DESCRIPTION
We were not recycling item views if the item contained a single
custom component child.

Instead of #740
Fixes #737
