### PR TITLE
fix(forms): add directives for formControl

### DIFF
--- a/nativescript-angular/value-accessors/checked-value-accessor.ts
+++ b/nativescript-angular/value-accessors/checked-value-accessor.ts
@@ -20,8 +20,8 @@ const CHECKED_VALUE_ACCESSOR = {
  */
 @Directive({
     selector:
-        "Switch[ngModel],Switch[formControlName]," +
-        "switch[ngModel],switch[formControlName]",
+        "Switch[ngModel],Switch[formControlName],Switch[formControl]," +
+        "switch[ngModel],switch[formControlName],switch[formControl]",
     providers: [CHECKED_VALUE_ACCESSOR],
     host: {
         "(touch)": "onTouched()",

--- a/nativescript-angular/value-accessors/date-value-accessor.ts
+++ b/nativescript-angular/value-accessors/date-value-accessor.ts
@@ -19,10 +19,10 @@ const DATE_VALUE_ACCESSOR = {
  *  ```
  */
 @Directive({
-    selector: "DatePicker[ngModel],DatePicker[formControlName]," +
-        "datepicker[ngModel],datepicker[formControlName]," +
-        "datePicker[ngModel],datePicker[formControlName]," +
-        "date-picker[ngModel],date-picker[formControlName]",
+    selector: "DatePicker[ngModel],DatePicker[formControlName],DatePicker[formControl]," +
+        "datepicker[ngModel],datepicker[formControlName],datepicker[formControl]," +
+        "datePicker[ngModel],datePicker[formControlName],datePicker[formControl]," +
+        "date-picker[ngModel],date-picker[formControlName],date-picker[formControl]",
     providers: [DATE_VALUE_ACCESSOR],
     host: {
         "(touch)": "onTouched()",

--- a/nativescript-angular/value-accessors/number-value-accessor.ts
+++ b/nativescript-angular/value-accessors/number-value-accessor.ts
@@ -20,8 +20,8 @@ const NUMBER_VALUE_ACCESSOR = {
  */
 @Directive({
     selector:
-        "Slider[ngModel],Slider[formControlName]," +
-        "slider[ngModel],slider[formControlName]",
+        "Slider[ngModel],Slider[formControlName],Slider[formControl]," +
+        "slider[ngModel],slider[formControlName],slider[formControl]",
     providers: [NUMBER_VALUE_ACCESSOR],
     host: {
         "(touch)": "onTouched()",

--- a/nativescript-angular/value-accessors/selectedIndex-value-accessor.ts
+++ b/nativescript-angular/value-accessors/selectedIndex-value-accessor.ts
@@ -22,20 +22,20 @@ export type SelectableView = {selectedIndex: number} & View;
  */
 @Directive({
     selector:
-        "SegmentedBar[ngModel],SegmentedBar[formControlName]," +
-        "segmentedBar[ngModel],segmentedBar[formControlName]," +
-        "segmentedbar[ngModel],segmentedbar[formControlName]," +
-        "segmented-bar[ngModel],segmented-bar[formControlName]," +
+        "SegmentedBar[ngModel],SegmentedBar[formControlName],SegmentedBar[formControl]," +
+        "segmentedBar[ngModel],segmentedBar[formControlName],segmentedBar[formControl]," +
+        "segmentedbar[ngModel],segmentedbar[formControlName],segmentedbar[formControl]," +
+        "segmented-bar[ngModel],segmented-bar[formControlName],segmented-bar[formControl]," +
 
-        "ListPicker[ngModel],ListPicker[formControlName]," +
-        "listPicker[ngModel],listPicker[formControlName]," +
-        "listpicker[ngModel],listpicker[formControlName]," +
-        "list-picker[ngModel],list-picker[formControlName]," +
+        "ListPicker[ngModel],ListPicker[formControlName],ListPicker[formControl]," +
+        "listPicker[ngModel],listPicker[formControlName],listPicker[formControl]," +
+        "listpicker[ngModel],listpicker[formControlName],listpicker[formControl]," +
+        "list-picker[ngModel],list-picker[formControlName],list-picker[formControl]," +
 
-        "TabView[ngModel],TabView[formControlName]," +
-        "tabView[ngModel],tabView[formControlName]," +
-        "tabview[ngModel],tabview[formControlName]," +
-        "tab-view[ngModel],tab-view[formControlName]",
+        "TabView[ngModel],TabView[formControlName],TabView[formControl]," +
+        "tabView[ngModel],tabView[formControlName],tabView[formControl]," +
+        "tabview[ngModel],tabview[formControlName],tabview[formControl]," +
+        "tab-view[ngModel],tab-view[formControlName],tab-view[formControl]",
     providers: [SELECTED_INDEX_VALUE_ACCESSOR],
     host: {
         "(touch)": "onTouched()",

--- a/nativescript-angular/value-accessors/text-value-accessor.ts
+++ b/nativescript-angular/value-accessors/text-value-accessor.ts
@@ -22,20 +22,20 @@ export type TextView = {text: string} & View;
  */
 @Directive({
     selector:
-        "TextField[ngModel],TextField[formControlName]," +
-        "textField[ngModel],textField[formControlName]," +
-        "textfield[ngModel],textfield[formControlName]," +
-        "text-field[ngModel],text-field[formControlName]," +
+        "TextField[ngModel],TextField[formControlName],TextField[formControl]," +
+        "textField[ngModel],textField[formControlName],textField[formControl]," +
+        "textfield[ngModel],textfield[formControlName],textfield[formControl]," +
+        "text-field[ngModel],text-field[formControlName],text-field[formControl]," +
 
-        "TextView[ngModel],TextView[formControlName]," +
-        "textView[ngModel],textView[formControlName]," +
-        "textview[ngModel],textview[formControlName]," +
-        "text-view[ngModel],text-view[formControlName]," +
+        "TextView[ngModel],TextView[formControlName],TextView[formControl]," +
+        "textView[ngModel],textView[formControlName],textView[formControl]," +
+        "textview[ngModel],textview[formControlName],textview[formControl]," +
+        "text-view[ngModel],text-view[formControlName],text-view[formControl]," +
 
-        "SearchBar[ngModel],SearchBar[formControlName]," +
-        "searchBar[ngModel],searchBar[formControlName]," +
-        "searchbar[ngModel],searchbar[formControlName]," +
-        "search-bar[ngModel], search-bar[formControlName]",
+        "SearchBar[ngModel],SearchBar[formControlName],SearchBar[formControl]," +
+        "searchBar[ngModel],searchBar[formControlName],searchBar[formControl]," +
+        "searchbar[ngModel],searchbar[formControlName],searchbar[formControl]," +
+        "search-bar[ngModel], search-bar[formControlName],search-bar[formControl]",
     providers: [TEXT_VALUE_ACCESSOR],
     host: {
         "(touch)": "onTouched()",

--- a/nativescript-angular/value-accessors/time-value-accessor.ts
+++ b/nativescript-angular/value-accessors/time-value-accessor.ts
@@ -20,10 +20,10 @@ const TIME_VALUE_ACCESSOR = {
  */
 @Directive({
     selector:
-        "TimePicker[ngModel],TimePicker[formControlName]," +
-        "timepicker[ngModel],timepicker[formControlName]," +
-        "timePicker[ngModel],timePicker[formControlName]," +
-        "time-picker[ngModel], time-picker[formControlName]",
+        "TimePicker[ngModel],TimePicker[formControlName],TimePicker[formControl]," +
+        "timepicker[ngModel],timepicker[formControlName],timepicker[formControl]," +
+        "timePicker[ngModel],timePicker[formControlName],timePicker[formControl]," +
+        "time-picker[ngModel],time-picker[formControlName],time-picker[formControl]",
     providers: [TIME_VALUE_ACCESSOR],
     host: {
         "(touch)": "onTouched()",


### PR DESCRIPTION
Somewhat related to #576 and #526

At the moment, selectors only apply to `ngModel` and `formControlName` meaning for Angular reactive forms to work with inputs, they must use `formControlName` within a `formGroup` directive.

I would like to add `[formControl]` to the list of selectors so that reactive forms can be used without a parent `formGroup`.

Rationale:
Say you have a dumb component which implements an input:
```
@Component({
  selector: 'my-custom-input',
  template: `<TextField [formControl]="control">`
})
export class MyCustomInput {
  @Input() control: FormControl
}
```

Which is used by some parent component:
```
@Component({
  selector: 'my-parent-component',
  template: `<my-custom-input [control]="formGroup.get('someControl')"`
})
export class MyCustomInput {
  public formGroup: FormGroup;
  constructor() {
    this.formGroup = new FormGroup({ someControl: new FormControl('') })
  }
}
```

The above does not work with the latest `nativescript-angular` with the following error: "No value accessor for form control with unspecified name attribute".

Adding the directives in the PR makes the above example work.