### PR TITLE
chore: update tns-core-modules peer dependency

### DIFF
--- a/nativescript-angular/package.json
+++ b/nativescript-angular/package.json
@@ -51,7 +51,7 @@
     "@angular/platform-browser": "~4.0.0 || ~4.1.0",
     "@angular/router": "~4.0.0 || ~4.1.0",
     "rxjs": "^5.0.1",
-    "tns-core-modules": "^3.1.0",
+    "tns-core-modules": "^3.1.0 || >3.2.0-",
     "zone.js": "^0.8.4"
   },
   "devDependencies": {


### PR DESCRIPTION
Command:
```
npm install tns-core-modules@next --save --verbose
```

Error:
```
npm WARN nativescript-angular@3.2.0-2017-7-4-1 requires a peer of tns-core-modules@^3.1.0 but none was installed.
/Users/nsbuilduser/workspace/tns-stable-build-testapps-webpack-hello-world-ng/TestApp
`-- (empty)

npm WARN nativescript-angular@3.2.0-2017-7-4-1 requires a peer of tns-core-modules@^3.1.0 but none was installed.
npm verb exit [ 0, true ]
npm verb code 1
```
