### PR TITLE
Add check to ns-router to maintain routing history when user triggers navigation but remains in the same place

### DIFF
--- a/nativescript-angular/router/ns-platform-location.ts
+++ b/nativescript-angular/router/ns-platform-location.ts
@@ -7,7 +7,7 @@ import { routerLog } from "../trace";
 @Injectable()
 export class NativescriptPlatformLocation extends PlatformLocation {
 
-    constructor(private locationStartegy: NSLocationStrategy) {
+    constructor(private locationStrategy: NSLocationStrategy) {
         super();
         routerLog("NativescriptPlatformLocation.constructor()");
     }
@@ -17,7 +17,7 @@ export class NativescriptPlatformLocation extends PlatformLocation {
     }
 
     onPopState(fn: LocationChangeListener): void {
-        this.locationStartegy.onPopState(fn);
+        this.locationStrategy.onPopState(fn);
     }
 
     onHashChange(_fn: LocationChangeListener): void {
@@ -30,18 +30,18 @@ export class NativescriptPlatformLocation extends PlatformLocation {
         return "";
     }
     get pathname(): string {
-        return this.locationStartegy.path();
+        return this.locationStrategy.path();
     }
     set pathname(_newPath: string) {
         throw new Error("NativescriptPlatformLocation set pathname - not implemented");
     }
 
     pushState(state: any, title: string, url: string): void {
-        this.locationStartegy.pushState(state, title, url, null);
+        this.locationStrategy.pushState(state, title, url, null);
     }
 
     replaceState(state: any, title: string, url: string): void {
-        this.locationStartegy.replaceState(state, title, url, null);
+        this.locationStrategy.replaceState(state, title, url, null);
     }
 
     forward(): void {
@@ -49,6 +49,6 @@ export class NativescriptPlatformLocation extends PlatformLocation {
     }
 
     back(): void {
-        this.locationStartegy.back();
+        this.locationStrategy.back();
     }
 }

--- a/nativescript-angular/router/ns-router-link.ts
+++ b/nativescript-angular/router/ns-router-link.ts
@@ -45,6 +45,7 @@ export class NSRouterLink implements OnChanges { // tslint:disable-line:directiv
     urlTree: UrlTree;
 
     private usePageRoute: boolean;
+    private currentPath: string;
 
     private get currentRoute(): ActivatedRoute {
         return this.usePageRoute ? this.pageRoute.activatedRoute.getValue() : this.route;
@@ -56,6 +57,7 @@ export class NSRouterLink implements OnChanges { // tslint:disable-line:directiv
         private route: ActivatedRoute,
         @Optional() private pageRoute: PageRoute) {
 
+        this.currentPath = this.router.url;
         this.usePageRoute = (this.pageRoute && this.route === this.pageRoute.activatedRoute.getValue());
     }
 
@@ -71,6 +73,8 @@ export class NSRouterLink implements OnChanges { // tslint:disable-line:directiv
 
     @HostListener("tap")
     onTap() {
+        this.clearHistory = !this.clearHistory ? this.clearHistory : this.hasPathChanged();
+
         routerLog("nsRouterLink.tapped: " + this.commands + " usePageRoute: " +
             this.usePageRoute + " clearHistory: " + this.clearHistory + " transition: " +
             JSON.stringify(this.pageTransition));
@@ -93,6 +97,10 @@ export class NSRouterLink implements OnChanges { // tslint:disable-line:directiv
 
     private convertClearHistory(value: boolean | string): boolean {
         return value === true || value === "true";
+    }
+
+    private hasPathChanged(): boolean {
+        return this.currentPath !== this.urlTree.toString();
     }
 
     private getTransition(): { animated: boolean, transition?: NavigationTransition } {


### PR DESCRIPTION
Currently when a user triggers navigation clearHistory is automatically triggered but this can lead to a user being trapped when the navigation path is one they are already on, effectively they do not move anywhere but the history is empty.

To fix this I made the following changes

**ns-router-links**
Added check to see if clearHistory is set to false - if it is it is because it has been set this way and therefore remains false
If it has not been set or is true a check is run to see if the current path and target path are the same
If they are then clearHistory is set to false to retain the history

_Other changes_

**ns-platform-location**
Fixed typo