### PR TITLE
feat(styling): Allow loading .css files as a fallback if no .scss file is found(#954)

### DIFF
--- a/nativescript-angular/file-system/ns-file-system.ts
+++ b/nativescript-angular/file-system/ns-file-system.ts
@@ -1,5 +1,5 @@
 import { Injectable } from "@angular/core";
-import { knownFolders, Folder } from "tns-core-modules/file-system";
+import { knownFolders, Folder, File } from "tns-core-modules/file-system";
 
 // Allows greater flexibility with `file-system` and Angular
 // Also provides a way for `file-system` to be mocked for testing
@@ -8,5 +8,13 @@ import { knownFolders, Folder } from "tns-core-modules/file-system";
 export class NSFileSystem {
   public currentApp(): Folder {
     return knownFolders.currentApp();
+  }
+
+  public fileFromPath(path: string): File {
+    return File.fromPath(path);
+  }
+
+  public fileExists(path: string): boolean {
+    return File.exists(path);
   }
 }

--- a/nativescript-angular/file-system/ns-file-system.ts
+++ b/nativescript-angular/file-system/ns-file-system.ts
@@ -6,15 +6,15 @@ import { knownFolders, Folder, File } from "tns-core-modules/file-system";
 
 @Injectable()
 export class NSFileSystem {
-  public currentApp(): Folder {
-    return knownFolders.currentApp();
-  }
+    public currentApp(): Folder {
+        return knownFolders.currentApp();
+    }
 
-  public fileFromPath(path: string): File {
-    return File.fromPath(path);
-  }
+    public fileFromPath(path: string): File {
+        return File.fromPath(path);
+    }
 
-  public fileExists(path: string): boolean {
-    return File.exists(path);
-  }
+    public fileExists(path: string): boolean {
+        return File.exists(path);
+    }
 }

--- a/nativescript-angular/platform.ts
+++ b/nativescript-angular/platform.ts
@@ -35,6 +35,7 @@ if ((<any>global).___TS_UNUSED) {
 import "./dom-adapter";
 
 import { NativeScriptElementSchemaRegistry } from "./schema-registry";
+import { NSFileSystem } from "./file-system/ns-file-system";
 import { FileSystemResourceLoader } from "./resource-loader";
 
 export const NS_COMPILER_PROVIDERS = [
@@ -43,6 +44,7 @@ export const NS_COMPILER_PROVIDERS = [
         provide: COMPILER_OPTIONS,
         useValue: {
             providers: [
+                NSFileSystem,
                 { provide: ResourceLoader, useClass: FileSystemResourceLoader },
                 { provide: ElementSchemaRegistry, useClass: NativeScriptElementSchemaRegistry },
             ]

--- a/tests/app/tests/xhr-paths.ts
+++ b/tests/app/tests/xhr-paths.ts
@@ -1,22 +1,68 @@
 // make sure you import mocha-config before @angular/core
-import {assert} from "./test-config";
-import {FileSystemResourceLoader} from "nativescript-angular/resource-loader";
+import { assert } from "./test-config";
+import { FileSystemResourceLoader } from "nativescript-angular/resource-loader";
+
+import { File } from "tns-core-modules/file-system";
+import { NSFileSystem } from "nativescript-angular/file-system/ns-file-system";
+
+class NSFileSystemMock {
+    public currentApp(): any {
+        return { path: "/app/dir" };
+    }
+
+    public fileFromPath(path: string): File {
+        return null;
+    }
+
+    public fileExists(path: string): boolean {
+        // mycomponent.html aways exists
+        // mycomponent.css is the other file
+        return path.indexOf("mycomponent.html") >= 0 || path === "/app/dir/mycomponent.css";
+    }
+}
+const fsMock = new NSFileSystemMock();
 
 describe("XHR name resolution", () => {
+    let resourceLoader: FileSystemResourceLoader;
+    before(() => {
+        resourceLoader = new FileSystemResourceLoader(new NSFileSystemMock());
+    });
+
     it("resolves relative paths from app root", () => {
-        const xhr = new FileSystemResourceLoader();
-        assert.strictEqual("/app/dir/mydir/mycomponent.html", xhr.resolve("mydir/mycomponent.html", "/app/dir"));
+        assert.strictEqual("/app/dir/mydir/mycomponent.html", resourceLoader.resolve("mydir/mycomponent.html"));
     });
 
     it("resolves double-slashed absolute paths as is", () => {
-        const xhr = new FileSystemResourceLoader();
-        assert.strictEqual("//app/mydir/mycomponent.html", xhr.resolve("//app/mydir/mycomponent.html", "/app/dir"));
+        assert.strictEqual("//app/mydir/mycomponent.html", resourceLoader.resolve("//app/mydir/mycomponent.html"));
     });
 
     it("resolves single-slashed absolute paths as is", () => {
-        const xhr = new FileSystemResourceLoader();
         assert.strictEqual(
             "/data/data/app/mydir/mycomponent.html",
-            xhr.resolve("/data/data/app/mydir/mycomponent.html", "/app/dir"));
+            resourceLoader.resolve("/data/data/app/mydir/mycomponent.html"));
+    });
+
+    it("resolves existing CSS file", () => {
+        assert.strictEqual(
+            "/app/dir/mycomponent.css",
+            resourceLoader.resolve("mycomponent.css"));
+    });
+
+    it("resolves non-existing .scss file to existing .css file", () => {
+        assert.strictEqual(
+            "/app/dir/mycomponent.css",
+            resourceLoader.resolve("mycomponent.scss"));
+    });
+
+    it("resolves non-existing .sass file to existing .css file", () => {
+        assert.strictEqual(
+            "/app/dir/mycomponent.css",
+            resourceLoader.resolve("mycomponent.sass"));
+    });
+
+    it("resolves non-existing .less file to existing .css file", () => {
+        assert.strictEqual(
+            "/app/dir/mycomponent.css",
+            resourceLoader.resolve("mycomponent.less"));
     });
 });

--- a/tests/app/tests/xhr-paths.ts
+++ b/tests/app/tests/xhr-paths.ts
@@ -15,7 +15,7 @@ class NSFileSystemMock {
     }
 
     public fileExists(path: string): boolean {
-        // mycomponent.html aways exists
+        // mycomponent.html always exists
         // mycomponent.css is the other file
         return path.indexOf("mycomponent.html") >= 0 || path === "/app/dir/mycomponent.css";
     }
@@ -64,5 +64,9 @@ describe("XHR name resolution", () => {
         assert.strictEqual(
             "/app/dir/mycomponent.css",
             resourceLoader.resolve("mycomponent.less"));
+    });
+
+    it("throws for non-existing file that has no fallbacks", () => {
+        assert.throws(() => resourceLoader.resolve("does-not-exist.css"));
     });
 });


### PR DESCRIPTION
Implements loading the corresponding `.css` file if `.scss` file was requested but not found.

Resolves: #954 
