### PR TITLE
The tns-core-modules tracer was intended to be called after an isEnabled check

### DIFF
--- a/nativescript-angular/renderer.ts
+++ b/nativescript-angular/renderer.ts
@@ -14,7 +14,7 @@ import { APP_ROOT_VIEW, DEVICE, getRootPage } from "./platform-providers";
 import { isBlank } from "./lang-facade";
 import { ViewUtil } from "./view-util";
 import { NgView, InvisibleNode } from "./element-registry";
-import { rendererLog as traceLog } from "./trace";
+import { rendererLog as log, isEnabled as isLogEnabled } from "./trace";
 
 // CONTENT_ATTR not exported from NativeScript_renderer - we need it for styles application.
 const COMPONENT_REGEX = /%COMP%/g;
@@ -81,120 +81,160 @@ export class NativeScriptRenderer extends Renderer2 {
         private viewUtil: ViewUtil
     ) {
         super();
-        traceLog("NativeScriptRenderer created");
+        if (isLogEnabled()) {
+            log("NativeScriptRenderer created");
+        }
     }
 
     @profile
     appendChild(parent: any, newChild: NgView): void {
-        traceLog(`NativeScriptRenderer.appendChild child: ${newChild} parent: ${parent}`);
+        if (isLogEnabled()) {
+            log(`NativeScriptRenderer.appendChild child: ${newChild} parent: ${parent}`);
+        }
         this.viewUtil.insertChild(parent, newChild);
     }
 
     @profile
     insertBefore(parent: NgView, newChild: NgView, refChildIndex: number): void {
-        traceLog(`NativeScriptRenderer.insertBefore child: ${newChild} parent: ${parent}`);
+        if (isLogEnabled()) {
+            log(`NativeScriptRenderer.insertBefore child: ${newChild} parent: ${parent}`);
+        }
         this.viewUtil.insertChild(parent, newChild, refChildIndex);
     }
 
     @profile
     removeChild(parent: any, oldChild: NgView): void {
-        traceLog(`NativeScriptRenderer.removeChild child: ${oldChild} parent: ${parent}`);
+        if (isLogEnabled()) {
+            log(`NativeScriptRenderer.removeChild child: ${oldChild} parent: ${parent}`);
+        }
         this.viewUtil.removeChild(parent, oldChild);
     }
 
     @profile
     selectRootElement(selector: string): NgView {
-        traceLog("NativeScriptRenderer.selectRootElement: " + selector);
+        if (isLogEnabled()) {
+            log("NativeScriptRenderer.selectRootElement: " + selector);
+        }
         return this.rootView;
     }
 
     @profile
     parentNode(node: NgView): any {
-        traceLog("NativeScriptRenderer.parentNode for node: " + node);
+        if (isLogEnabled()) {
+            log("NativeScriptRenderer.parentNode for node: " + node);
+        }
         return node.parent || node.templateParent;
     }
 
     @profile
     nextSibling(node: NgView): number {
-        traceLog(`NativeScriptRenderer.nextSibling ${node}`);
+        if (isLogEnabled()) {
+            log(`NativeScriptRenderer.nextSibling ${node}`);
+        }
         return this.viewUtil.nextSiblingIndex(node);
     }
 
     @profile
     createComment(_value: any): InvisibleNode {
-        traceLog(`NativeScriptRenderer.createComment ${_value}`);
+        if (isLogEnabled()) {
+            log(`NativeScriptRenderer.createComment ${_value}`);
+        }
         return this.viewUtil.createComment();
     }
 
     @profile
     createElement(name: any, _namespace: string): NgView {
-        traceLog(`NativeScriptRenderer.createElement: ${name}`);
+        if (isLogEnabled()) {
+            log(`NativeScriptRenderer.createElement: ${name}`);
+        }
         return this.viewUtil.createView(name);
     }
 
     @profile
     createText(_value: string): InvisibleNode {
-        traceLog(`NativeScriptRenderer.createText ${_value}`);
+        if (isLogEnabled()) {
+            log(`NativeScriptRenderer.createText ${_value}`);
+        }
         return this.viewUtil.createText();
     }
 
     @profile
     createViewRoot(hostElement: NgView): NgView {
-        traceLog(`NativeScriptRenderer.createViewRoot ${hostElement.nodeName}`);
+        if (isLogEnabled()) {
+            log(`NativeScriptRenderer.createViewRoot ${hostElement.nodeName}`);
+        }
         return hostElement;
     }
 
     @profile
     projectNodes(parentElement: NgView, nodes: NgView[]): void {
-        traceLog("NativeScriptRenderer.projectNodes");
+        if (isLogEnabled()) {
+            log("NativeScriptRenderer.projectNodes");
+        }
         nodes.forEach((node) => this.viewUtil.insertChild(parentElement, node));
     }
 
     @profile
     destroy() {
-        traceLog("NativeScriptRenderer.destroy");
+        if (isLogEnabled()) {
+            log("NativeScriptRenderer.destroy");
+        }
         // Seems to be called on component dispose only (router outlet)
         // TODO: handle this when we resolve routing and navigation.
     }
 
     @profile
     setAttribute(view: NgView, name: string, value: string, namespace?: string) {
-        traceLog(`NativeScriptRenderer.setAttribute ${view} : ${name} = ${value}, namespace: ${namespace}`);
+        if (isLogEnabled()) {
+            log(`NativeScriptRenderer.setAttribute ${view} : ${name} = ${value}, namespace: ${namespace}`);
+        }
         return this.viewUtil.setProperty(view, name, value, namespace);
     }
 
     @profile
     removeAttribute(_el: NgView, _name: string): void {
-        traceLog(`NativeScriptRenderer.removeAttribute ${_el}: ${_name}`);
+        if (isLogEnabled()) {
+            log(`NativeScriptRenderer.removeAttribute ${_el}: ${_name}`);
+        }
     }
 
     @profile
     setProperty(view: any, name: string, value: any) {
-        traceLog(`NativeScriptRenderer.setProperty ${view} : ${name} = ${value}`);
+        if (isLogEnabled()) {
+            log(`NativeScriptRenderer.setProperty ${view} : ${name} = ${value}`);
+        }
         return this.viewUtil.setProperty(view, name, value);
     }
 
     @profile
     addClass(view: NgView, name: string): void {
-        traceLog(`NativeScriptRenderer.addClass ${name}`);
+        if (isLogEnabled()) {
+            log(`NativeScriptRenderer.addClass ${name}`);
+        }
         this.viewUtil.addClass(view, name);
     }
 
     @profile
     removeClass(view: NgView, name: string): void {
-        traceLog(`NativeScriptRenderer.removeClass ${name}`);
+        if (isLogEnabled()) {
+            log(`NativeScriptRenderer.removeClass ${name}`);
+        }
         this.viewUtil.removeClass(view, name);
     }
 
     @profile
     setStyle(view: NgView, styleName: string, value: any, _flags?: RendererStyleFlags2): void {
-        traceLog(`NativeScriptRenderer.setStyle: ${styleName} = ${value}`);
+        if (isLogEnabled()) {
+            log(`NativeScriptRenderer.setStyle: ${styleName} = ${value}`);
+        }
         this.viewUtil.setStyle(view, styleName, value);
     }
 
     @profile
     removeStyle(view: NgView, styleName: string, _flags?: RendererStyleFlags2): void {
-        traceLog("NativeScriptRenderer.removeStyle: ${styleName}");
+        if (isLogEnabled()) {
+            log("NativeScriptRenderer.removeStyle: ${styleName}");
+        }
         this.viewUtil.removeStyle(view, styleName);
     }
 
@@ -202,32 +242,41 @@ export class NativeScriptRenderer extends Renderer2 {
     // such as <template> placeholders.
     @profile
     setBindingDebugInfo(renderElement: NgView, propertyName: string, propertyValue: string): void {
-        traceLog("NativeScriptRenderer.setBindingDebugInfo: " + renderElement + ", " +
-            propertyName + " = " + propertyValue);
+        if (isLogEnabled()) {
+            log("NativeScriptRenderer.setBindingDebugInfo: " + renderElement + ", " +
+                propertyName + " = " + propertyValue);
+        }
     }
 
     @profile
     setElementDebugInfo(renderElement: any, _info: any /*RenderDebugInfo*/): void {
-        traceLog("NativeScriptRenderer.setElementDebugInfo: " + renderElement);
+        if (isLogEnabled()) {
+            log("NativeScriptRenderer.setElementDebugInfo: " + renderElement);
+        }
     }
 
     @profile
     invokeElementMethod(_renderElement: NgView, methodName: string, args: Array<any>) {
-        traceLog("NativeScriptRenderer.invokeElementMethod " + methodName + " " + args);
+        if (isLogEnabled()) {
+            log("NativeScriptRenderer.invokeElementMethod " + methodName + " " + args);
+        }
     }
 
     @profile
     setValue(_renderNode: any, _value: string) {
-        traceLog(
-            `NativeScriptRenderer.setValue ` +
-            `renderNode: ${_renderNode}, value: ${_value}`
-        );
+        if (isLogEnabled()) {
+            log(
+                `NativeScriptRenderer.setValue ` +
+                `renderNode: ${_renderNode}, value: ${_value}`
+            );
+        }
     }
 
     @profile
-    listen(renderElement: any, eventName: string, callback: (event: any) => boolean):
-        () => void {
-        traceLog("NativeScriptRenderer.listen: " + eventName);
+    listen(renderElement: any, eventName: string, callback: (event: any) => boolean): () => void {
+        if (isLogEnabled()) {
+            log("NativeScriptRenderer.listen: " + eventName);
+        }
         // Explicitly wrap in zone
         let zonedCallback = (...args) => {
             this.zone.run(() => {

--- a/nativescript-angular/router/page-router-outlet.ts
+++ b/nativescript-angular/router/page-router-outlet.ts
@@ -20,7 +20,7 @@ import { BehaviorSubject } from "rxjs/BehaviorSubject";
 
 import { isPresent } from "../lang-facade";
 import { DEVICE, PAGE_FACTORY, PageFactory } from "../platform-providers";
-import { routerLog } from "../trace";
+import { routerLog as log, isEnabled as isLogEnabled } from "../trace";
 import { DetachedLoader } from "../common/detached-loader";
 import { ViewUtil } from "../view-util";
 import { NSLocationStrategy } from "./ns-location-strategy";
@@ -89,10 +89,7 @@ interface CacheItem {
     loaderRef?: ComponentRef<any>;
 }
 
-
 type ProviderMap = Map<Type<any>|InjectionToken<any>, any>;
-
-const log = (msg: string) => routerLog(msg);
 
 @Directive({ selector: "page-router-outlet" }) // tslint:disable-line:directive-selector
 export class PageRouterOutlet implements OnDestroy, OnInit { // tslint:disable-line:directive-class-suffix
@@ -148,7 +145,9 @@ export class PageRouterOutlet implements OnDestroy, OnInit { // tslint:disable-l
 
         this.viewUtil = new ViewUtil(device);
         this.detachedLoaderFactory = resolver.resolveComponentFactory(DetachedLoader);
-        log("DetachedLoaderFactory loaded");
+        if (isLogEnabled()) {
+            log("DetachedLoaderFactory loaded");
+        }
     }
 
     ngOnDestroy(): void {
@@ -178,7 +177,9 @@ export class PageRouterOutlet implements OnDestroy, OnInit { // tslint:disable-l
 
     deactivate(): void {
         if (this.locationStrategy._isPageNavigatingBack()) {
-            log("PageRouterOutlet.deactivate() while going back - should destroy");
+            if (isLogEnabled()) {
+                log("PageRouterOutlet.deactivate() while going back - should destroy");
+            }
             if (!this.isActivated) {
                 return;
             }
@@ -193,7 +194,9 @@ export class PageRouterOutlet implements OnDestroy, OnInit { // tslint:disable-l
             RefCache.destroyItem(poppedItem);
             this.activated = null;
         } else {
-            log("PageRouterOutlet.deactivate() while going forward - do nothing");
+            if (isLogEnabled()) {
+                log("PageRouterOutlet.deactivate() while going forward - do nothing");
+            }
         }
     }
 
@@ -232,9 +235,11 @@ export class PageRouterOutlet implements OnDestroy, OnInit { // tslint:disable-l
      * Called when the `RouteReuseStrategy` instructs to re-attach a previously detached subtree
      */
     attach(ref: ComponentRef<any>, activatedRoute: ActivatedRoute) {
-        log("PageRouterOutlet.attach()" +
-            "when RouteReuseStrategy instructs to re-attach " +
-            "previously detached subtree");
+        if (isLogEnabled()) {
+            log("PageRouterOutlet.attach()" +
+                "when RouteReuseStrategy instructs to re-attach " +
+                "previously detached subtree");
+        }
 
         this.activated = ref;
         this._activatedRoute = activatedRoute;
@@ -250,9 +255,10 @@ export class PageRouterOutlet implements OnDestroy, OnInit { // tslint:disable-l
         activatedRoute: ActivatedRoute,
         resolver: ComponentFactoryResolver|null
     ): void {
-
-        log("PageRouterOutlet.activateWith() - " +
-            "instanciating new component during commit phase of a navigation");
+        if (isLogEnabled()) {
+            log("PageRouterOutlet.activateWith() - " +
+                "instanciating new component during commit phase of a navigation");
+        }
 
         this._activatedRoute = activatedRoute;
         resolver = resolver || this.resolver;
@@ -275,7 +281,9 @@ export class PageRouterOutlet implements OnDestroy, OnInit { // tslint:disable-l
         const factory = this.getComponentFactory(activatedRoute, loadedResolver);
 
         if (this.isInitialPage) {
-            log("PageRouterOutlet.activate() initial page - just load component");
+            if (isLogEnabled()) {
+                log("PageRouterOutlet.activate() initial page - just load component");
+            }
 
             this.isInitialPage = false;
 
@@ -289,8 +297,10 @@ export class PageRouterOutlet implements OnDestroy, OnInit { // tslint:disable-l
                 loaderRef: null,
             });
         } else {
-            log("PageRouterOutlet.activate() forward navigation - " +
-                "create detached loader in the loader container");
+            if (isLogEnabled()) {
+                log("PageRouterOutlet.activate() forward navigation - " +
+                    "create detached loader in the loader container");
+            }
 
             const page = this.pageFactory({
                 isNavigation: true,
@@ -330,7 +340,9 @@ export class PageRouterOutlet implements OnDestroy, OnInit { // tslint:disable-l
     }
 
     private activateOnGoBack(activatedRoute: ActivatedRoute): void {
-        log("PageRouterOutlet.activate() - Back navigation, so load from cache");
+        if (isLogEnabled()) {
+            log("PageRouterOutlet.activate() - Back navigation, so load from cache");
+        }
 
         this.locationStrategy._finishBackPageNavigation();
 

--- a/nativescript-angular/trace.ts
+++ b/nativescript-angular/trace.ts
@@ -1,4 +1,5 @@
 import { write, categories, messageType } from "tns-core-modules/trace";
+export { isEnabled } from "tns-core-modules/trace";
 
 export const animationsTraceCategory = "ns-animations";
 export const rendererTraceCategory = "ns-renderer";

--- a/nativescript-angular/view-util.ts
+++ b/nativescript-angular/view-util.ts
@@ -17,7 +17,8 @@ import {
 } from "./element-registry";
 
 import { platformNames, Device } from "tns-core-modules/platform";
-import { rendererLog as traceLog } from "./trace";
+import { rendererLog as log, isEnabled as isLogEnabled } from "./trace";
+import { profile } from "tns-core-modules/profiling";
 
 const XML_ATTRIBUTES = Object.freeze(["style", "rows", "columns", "fontAttributes"]);
 const ELEMENT_NODE_TYPE = 1;
@@ -118,7 +119,9 @@ export class ViewUtil {
     }
 
     public createView(name: string): NgView {
-        traceLog(`Creating view: ${name}`);
+        if (isLogEnabled()) {
+            log(`Creating view: ${name}`);
+        }
 
         if (!isKnownView(name)) {
             name = "ProxyViewContainer";
@@ -197,7 +200,9 @@ export class ViewUtil {
 
 
     private setPropertyInternal(view: NgView, attributeName: string, value: any): void {
-        traceLog(`Setting attribute: ${attributeName}=${value} to ${view}`);
+        if (isLogEnabled()) {
+            log(`Setting attribute: ${attributeName}=${value} to ${view}`);
+        }
 
         if (attributeName === "class") {
             this.setClasses(view, value);


### PR DESCRIPTION
For chatty calls (such as setAttribute) string concatenation and object toString() calls may add some overhead.