### PR TITLE
refactor: resource loader

### DIFF
--- a/nativescript-angular/file-system/ns-file-system.ts
+++ b/nativescript-angular/file-system/ns-file-system.ts
@@ -6,15 +6,15 @@ import { knownFolders, Folder, File } from "tns-core-modules/file-system";
 
 @Injectable()
 export class NSFileSystem {
-  public currentApp(): Folder {
-    return knownFolders.currentApp();
-  }
+    public currentApp(): Folder {
+        return knownFolders.currentApp();
+    }
 
-  public fileFromPath(path: string): File {
-    return File.fromPath(path);
-  }
+    public fileFromPath(path: string): File {
+        return File.fromPath(path);
+    }
 
-  public fileExists(path: string): boolean {
-    return File.exists(path);
-  }
+    public fileExists(path: string): boolean {
+        return File.exists(path);
+    }
 }

--- a/tests/app/tests/xhr-paths.ts
+++ b/tests/app/tests/xhr-paths.ts
@@ -15,7 +15,7 @@ class NSFileSystemMock {
     }
 
     public fileExists(path: string): boolean {
-        // mycomponent.html aways exists
+        // mycomponent.html always exists
         // mycomponent.css is the other file
         return path.indexOf("mycomponent.html") >= 0 || path === "/app/dir/mycomponent.css";
     }

--- a/tests/app/tests/xhr-paths.ts
+++ b/tests/app/tests/xhr-paths.ts
@@ -65,4 +65,8 @@ describe("XHR name resolution", () => {
             "/app/dir/mycomponent.css",
             resourceLoader.resolve("mycomponent.less"));
     });
+
+    it("throws for non-existing file that has no fallbacks", () => {
+        assert.throws(() => resourceLoader.resolve("does-not-exist.css"));
+    });
 });


### PR DESCRIPTION
- makes `resolveRelativeUrls` private method of `NSFileSystem`
- extracts fallback resolution to a private method
- makes `ns-file-system` use 4 spaces instead of 2
- add test to assert that resource loader resolver throws for non-existing files that has no fallback resources either