### PR TITLE
refactor: ActionBar directive and patching of Views in renderer 

### DIFF
--- a/e2e/renderer/app/action-bar/action-bar-dynamic-items.component.ts
+++ b/e2e/renderer/app/action-bar/action-bar-dynamic-items.component.ts
@@ -1,0 +1,27 @@
+import { Component } from "@angular/core";
+
+@Component({
+  template: `
+    <ActionBar title="Action Bar Dynamic Items">
+        <NavigationButton
+            *ngIf="showNavigationButton"
+            android.systemIcon="ic_menu_back"
+        ></NavigationButton>
+
+        <ActionItem text="one" *ngIf="show1"></ActionItem>
+        <ActionItem text="two" *ngIf="show2"></ActionItem>
+    </ActionBar>
+
+    <StackLayout>
+        <Button text="toggle nav" (tap)="showNavigationButton = !showNavigationButton"></Button>
+        <Button text="toggle 1" (tap)="show1 = !show1"></Button>
+        <Button text="toggle 2" (tap)="show2 = !show2"></Button>
+    </StackLayout>
+  `
+})
+export class ActionBarDynamicItemsComponent {
+    public showNavigationButton = true;
+    public show1 = true;
+    public show2 = true;
+}
+

--- a/e2e/renderer/app/action-bar/action-bar-extension.component.ts
+++ b/e2e/renderer/app/action-bar/action-bar-extension.component.ts
@@ -1,0 +1,16 @@
+import { Component } from "@angular/core";
+
+@Component({
+    template: `
+        <ActionBarExtension>
+            <ActionItem (tap)="show = !show" text="toggle">
+            </ActionItem>
+
+            <ActionItem *ngIf="show" text="conditional">
+            </ActionItem>
+        </ActionBarExtension>
+  `
+})
+export class ActionBarExtensionComponent {
+    public show = true;
+}

--- a/e2e/renderer/app/app-routing.module.ts
+++ b/e2e/renderer/app/app-routing.module.ts
@@ -1,6 +1,8 @@
 import { NgModule, NO_ERRORS_SCHEMA } from "@angular/core";
 import { NativeScriptRouterModule } from "nativescript-angular/router";
 
+import { ActionBarDynamicItemsComponent } from "./action-bar/action-bar-dynamic-items.component";
+
 import { ListComponent } from "./list.component";
 import { NgForComponent } from "./ngfor.component";
 import { NgForOfComponent } from "./ngforof.component";
@@ -16,6 +18,10 @@ export const routes = [
         path: "",
         redirectTo: "/list",
         pathMatch: "full"
+    },
+    {
+        path: "action-bar-dynamic",
+        component: ActionBarDynamicItemsComponent,
     },
     {
         path: "list",
@@ -56,6 +62,7 @@ export const routes = [
 ];
 
 export const navigatableComponents = [
+    ActionBarDynamicItemsComponent,
     ListComponent,
     NgForComponent,
     NgForOfComponent,

--- a/e2e/renderer/app/app-routing.module.ts
+++ b/e2e/renderer/app/app-routing.module.ts
@@ -2,6 +2,7 @@ import { NgModule, NO_ERRORS_SCHEMA } from "@angular/core";
 import { NativeScriptRouterModule } from "nativescript-angular/router";
 
 import { ActionBarDynamicItemsComponent } from "./action-bar/action-bar-dynamic-items.component";
+import { ActionBarExtensionComponent } from "./action-bar/action-bar-extension.component";
 
 import { ListComponent } from "./list.component";
 import { NgForComponent } from "./ngfor.component";
@@ -22,6 +23,10 @@ export const routes = [
     {
         path: "action-bar-dynamic",
         component: ActionBarDynamicItemsComponent,
+    },
+    {
+        path: "action-bar-extension",
+        component: ActionBarExtensionComponent,
     },
     {
         path: "list",
@@ -63,6 +68,8 @@ export const routes = [
 
 export const navigatableComponents = [
     ActionBarDynamicItemsComponent,
+    ActionBarExtensionComponent,
+
     ListComponent,
     NgForComponent,
     NgForOfComponent,

--- a/e2e/renderer/app/content-view.component.ts
+++ b/e2e/renderer/app/content-view.component.ts
@@ -1,7 +1,6 @@
 import { Component } from "@angular/core";
 
 @Component({
-  selector: "my-app",
   template: `
     <ActionBar title="Content View">
         <ActionItem (tap)="toggle()">

--- a/e2e/renderer/app/list.component.ts
+++ b/e2e/renderer/app/list.component.ts
@@ -4,6 +4,7 @@ import { Component } from "@angular/core";
     template: `
         <FlexboxLayout flexDirection="column">
             <Button text="ActionBar dynamic" [nsRouterLink]="['/action-bar-dynamic']"></Button>
+            <Button text="ActionBarExtension" [nsRouterLink]="['/action-bar-extension']"></Button>
             <Button text="NgFor" [nsRouterLink]="['/ngfor']"></Button>
             <Button text="NgForOf" [nsRouterLink]="['/ngforof']"></Button>
             <Button text="NgIf no layout" [nsRouterLink]="['/ngif-no-layout']"></Button>

--- a/e2e/renderer/app/list.component.ts
+++ b/e2e/renderer/app/list.component.ts
@@ -3,6 +3,7 @@ import { Component } from "@angular/core";
 @Component({
     template: `
         <FlexboxLayout flexDirection="column">
+            <Button text="ActionBar dynamic" [nsRouterLink]="['/action-bar-dynamic']"></Button>
             <Button text="NgFor" [nsRouterLink]="['/ngfor']"></Button>
             <Button text="NgForOf" [nsRouterLink]="['/ngforof']"></Button>
             <Button text="NgIf no layout" [nsRouterLink]="['/ngif-no-layout']"></Button>

--- a/e2e/renderer/e2e/action-bar.e2e-spec.ts
+++ b/e2e/renderer/e2e/action-bar.e2e-spec.ts
@@ -1,0 +1,163 @@
+import {
+    AppiumDriver,
+    createDriver,
+    SearchOptions,
+    elementHelper,
+} from "nativescript-dev-appium";
+
+import { isOnTheLeft } from "./helpers/location";
+import { DriverWrapper, ExtendedUIElement } from "./helpers/appium-elements";
+
+describe("Action Bar scenario", () => {
+    let driver: AppiumDriver;
+    let driverWrapper: DriverWrapper;
+
+    describe("dynamically add/remove ActionItems", async () => {
+        let firstActionItem: ExtendedUIElement;
+        let secondActionItem: ExtendedUIElement;
+        let toggleFirstButton: ExtendedUIElement;
+        let toggleSecondButton: ExtendedUIElement;
+
+        before(async () => {
+            driver = await createDriver();
+            driverWrapper = new DriverWrapper(driver);
+        });
+
+        after(async () => {
+            await driver.quit();
+            console.log("Driver quits!");
+        });
+
+        it("should navigate to page", async () => {
+            const navigationButton =
+                await driverWrapper.findElementByText("ActionBar dynamic", SearchOptions.exact);
+            await navigationButton.click();
+
+            const actionBar =
+                await driverWrapper.findElementByText("Action Bar Dynamic Items", SearchOptions.exact);
+        });
+
+        it("should find elements", async () => {
+            firstActionItem = await driverWrapper.findElementByText("one");
+            secondActionItem = await driverWrapper.findElementByText("two");
+
+            toggleFirstButton = await driverWrapper.findElementByText("toggle 1");
+            toggleSecondButton = await driverWrapper.findElementByText("toggle 2");
+        });
+
+        it("should initially render the action items in the correct order", async () => {
+            await checkOrderIsCorrect();
+        });
+
+        it("should detach first element when its condition is false", done => {
+            (async () => {
+                await toggleFirst();
+
+                try {
+                    await driverWrapper.findElementByText("one", SearchOptions.exact);
+                } catch (e) {
+                    done();
+                }
+            })();
+        });
+
+        it("should attach first element in the correct position", async () => {
+            await toggleFirst();
+            await checkOrderIsCorrect();
+        });
+
+        it("should detach second element when its condition is false", done => {
+            (async () => {
+                await toggleSecond();
+
+                try {
+                    await driverWrapper.findElementByText("two", SearchOptions.exact);
+                } catch (e) {
+                    done();
+                }
+            })();
+        });
+
+        it("should attach second element in the correct position", async () => {
+            await toggleSecond();
+            await checkOrderIsCorrect();
+        });
+
+        it("should detach and then reattach both at correct places", async () => {
+            await toggleFirst();
+            await toggleSecond();
+
+            await toggleFirst();
+            await toggleSecond();
+
+            await checkOrderIsCorrect();
+        });
+
+        const checkOrderIsCorrect = async () => {
+            await isOnTheLeft(firstActionItem, secondActionItem);
+        };
+
+        const toggleFirst = async () => {
+            toggleFirstButton = await toggleFirstButton.refetch();
+            await toggleFirstButton.click();
+        };
+
+        const toggleSecond = async () => {
+            toggleSecondButton = await toggleSecondButton.refetch();
+            await toggleSecondButton.click();
+        };
+
+    });
+
+    describe("Action Bar extension with dynamic ActionItem", async () => {
+        let toggleButton: ExtendedUIElement;
+        let conditional: ExtendedUIElement;
+
+        before(async () => {
+            driver = await createDriver();
+            driverWrapper = new DriverWrapper(driver);
+        });
+
+        after(async () => {
+            await driver.quit();
+            console.log("Driver quits!");
+        });
+
+        it("should navigate to page", async () => {
+            const navigationButton =
+                await driverWrapper.findElementByText("ActionBarExtension", SearchOptions.exact);
+            await navigationButton.click();
+        });
+
+        it("should find elements", async () => {
+            toggleButton = await driverWrapper.findElementByText("toggle");
+            conditional = await driverWrapper.findElementByText("conditional");
+        });
+
+        it("should detach conditional action item when its condition is false", done => {
+            (async () => {
+                await toggle();
+
+                try {
+                    await driverWrapper.findElementByText("conditional", SearchOptions.exact);
+                } catch (e) {
+                    done();
+                }
+            })();
+        });
+
+        it("should reattach conditional action item at correct place", async () => {
+            await toggle();
+            await checkOrderIsCorrect();
+        });
+        
+        const checkOrderIsCorrect = async () => {
+            await isOnTheLeft(toggleButton, conditional);
+        };
+
+        const toggle = async () => {
+            toggleButton = await toggleButton.refetch();
+            await toggleButton.click();
+        };
+    });
+});

--- a/e2e/renderer/e2e/helpers/appium-elements.ts
+++ b/e2e/renderer/e2e/helpers/appium-elements.ts
@@ -38,4 +38,25 @@ export class DriverWrapper {
 
         return result;
     }
+
+    @refetchable()
+    async findElementByXPath(...args: any[]): Promise<ExtendedUIElement> {
+        const result = await (<any>this.driver).findElementByXPath(...args);
+
+        return result;
+    }
+
+    @refetchable()
+    async findElementsByXPath(...args: any[]): Promise<ExtendedUIElement[]> {
+        const result = await (<any>this.driver).findElementsByXPath(...args);
+
+        return result || [];
+    }
+
+    @refetchable()
+    async findElementsByClassName(...args: any[]): Promise<ExtendedUIElement[]> {
+        const result = await (<any>this.driver).findElementsByClassName(...args);
+
+        return result || [];
+    }
 }

--- a/e2e/renderer/e2e/helpers/location.ts
+++ b/e2e/renderer/e2e/helpers/location.ts
@@ -11,3 +11,14 @@ export const isAbove = async (first: ExtendedUIElement, second: ExtendedUIElemen
 
     assert.isTrue(firstY < secondY);
 }
+
+export const isOnTheLeft = async (first: ExtendedUIElement, second: ExtendedUIElement) => {
+    first = await first.refetch();
+    second = await second.refetch();
+
+    const { x: firstX } = await first.location();
+    const { x: secondX } = await second.location();
+
+    assert.isTrue(firstX < secondX);
+}
+

--- a/nativescript-angular/directives/action-bar.ts
+++ b/nativescript-angular/directives/action-bar.ts
@@ -1,5 +1,10 @@
 import { Directive, Component, ElementRef, Optional, OnDestroy } from "@angular/core";
-import { ActionItem, ActionBar, NavigationButton } from "tns-core-modules/ui/action-bar";
+import {
+    ActionBar,
+    ActionItem,
+    ActionItems,
+    NavigationButton,
+} from "tns-core-modules/ui/action-bar";
 import { Page } from "tns-core-modules/ui/page";
 import { View } from "tns-core-modules/ui/core/view";
 
@@ -25,14 +30,14 @@ type NgActionBar = (ActionBar & ViewExtensions);
 
 const actionBarMeta: ViewClassMeta = {
     skipAddToDom: true,
-    insertChild: (parent: NgActionBar, child: NgView, previous: NgView) => {
+    insertChild: (parent: NgActionBar, child: NgView, next: any) => {
         if (isInvisibleNode(child)) {
             return;
         } else if (isNavigationButton(child)) {
             parent.navigationButton = child;
             child.templateParent = parent;
         } else if (isActionItem(child)) {
-            parent.actionItems.addItem(child);
+            addActionItem(parent, child, next);
             child.templateParent = parent;
         } else if (isView(child)) {
             parent.titleView = child;
@@ -54,6 +59,28 @@ const actionBarMeta: ViewClassMeta = {
             parent.titleView = null;
         }
     },
+};
+
+const addActionItem = (bar: NgActionBar, item: ActionItem, next: ActionItem) => {
+    if (next) {
+        insertActionItemBefore(bar, item, next);
+    } else {
+        appendActionItem(bar, item);
+    }
+};
+
+const insertActionItemBefore = (bar: NgActionBar, item: ActionItem, next: ActionItem) => {
+    const actionItems: ActionItems = bar.actionItems;
+    const actionItemsCollection: ActionItem[] = actionItems.getItems();
+
+    const indexToInsert = actionItemsCollection.indexOf(next);
+    actionItemsCollection.splice(indexToInsert, 0, item);
+
+    (<any>actionItems).setItems(actionItemsCollection);
+};
+
+const appendActionItem = (bar: NgActionBar, item: ActionItem) => {
+    bar.actionItems.addItem(item);
 };
 
 registerElement("ActionBar", () => require("ui/action-bar").ActionBar, actionBarMeta);

--- a/nativescript-angular/directives/action-bar.ts
+++ b/nativescript-angular/directives/action-bar.ts
@@ -6,7 +6,6 @@ import {
     NavigationButton,
 } from "tns-core-modules/ui/action-bar";
 import { Page } from "tns-core-modules/ui/page";
-import { View } from "tns-core-modules/ui/core/view";
 
 import { isBlank } from "../lang-facade";
 import {

--- a/nativescript-angular/directives/action-bar.ts
+++ b/nativescript-angular/directives/action-bar.ts
@@ -5,46 +5,53 @@ import { View } from "tns-core-modules/ui/core/view";
 
 import { isBlank } from "../lang-facade";
 import {
-    InvisibleNode,
     NgView,
     ViewClassMeta,
+    ViewExtensions,
+    isInvisibleNode,
+    isView,
     registerElement,
 } from "../element-registry";
 
+export function isActionItem(view: any): view is ActionItem {
+    return view instanceof ActionItem;
+}
+
+export function isNavigationButton(view: any): view is NavigationButton {
+    return view instanceof NavigationButton;
+}
+
+type NgActionBar = (ActionBar & ViewExtensions);
+
 const actionBarMeta: ViewClassMeta = {
     skipAddToDom: true,
-    insertChild: (parent: NgView, child: NgView) => {
-        const bar = <ActionBar>(<any>parent);
-        const childView = <any>child;
-
-        if (child instanceof InvisibleNode) {
+    insertChild: (parent: NgActionBar, child: NgView, previous: NgView) => {
+        if (isInvisibleNode(child)) {
             return;
-        } else if (child instanceof NavigationButton) {
-            bar.navigationButton = childView;
-            childView.parent = bar;
-        } else if (child instanceof ActionItem) {
-            bar.actionItems.addItem(childView);
-            childView.parent = bar;
-        } else if (child instanceof View) {
-            bar.titleView = childView;
+        } else if (isNavigationButton(child)) {
+            parent.navigationButton = child;
+            child.templateParent = parent;
+        } else if (isActionItem(child)) {
+            parent.actionItems.addItem(child);
+            child.templateParent = parent;
+        } else if (isView(child)) {
+            parent.titleView = child;
         }
     },
-    removeChild: (parent: NgView, child: NgView) => {
-        const bar = <ActionBar>(<any>parent);
-        const childView = <any>child;
-
-        if (child instanceof InvisibleNode) {
+    removeChild: (parent: NgActionBar, child: NgView) => {
+        if (isInvisibleNode(child)) {
             return;
-        } else if (child instanceof NavigationButton) {
-            if (bar.navigationButton === childView) {
-                bar.navigationButton = null;
+        } else if (isNavigationButton(child)) {
+            if (parent.navigationButton === child) {
+                parent.navigationButton = null;
             }
-            childView.parent = null;
-        } else if (child instanceof ActionItem) {
-            bar.actionItems.removeItem(childView);
-            childView.parent = null;
-        } else if (child instanceof View && bar.titleView && bar.titleView === childView) {
-            bar.titleView = null;
+
+            child.templateParent = null;
+        } else if (isActionItem(child)) {
+            parent.actionItems.removeItem(child);
+            child.templateParent = null;
+        } else if (isView(child) && parent.titleView && parent.titleView === child) {
+            parent.titleView = null;
         }
     },
 };

--- a/nativescript-angular/element-registry.ts
+++ b/nativescript-angular/element-registry.ts
@@ -72,12 +72,20 @@ const getClassName = instance => instance.constructor.name;
 
 export interface ViewClassMeta {
     skipAddToDom?: boolean;
-    insertChild?: (parent: NgView, child: NgView) => void;
-    removeChild?: (parent: NgView, child: NgView) => void;
+    insertChild?: (parent: any, child: any, previous?: any, next?: any) => void;
+    removeChild?: (parent: any, child: any) => void;
 }
 
 export function isDetachedElement(element): boolean {
     return (element && element.meta && element.meta.skipAddToDom);
+}
+
+export function isView(view: any): view is NgView {
+    return view instanceof View;
+}
+
+export function isInvisibleNode(view: any): view is InvisibleNode {
+    return view instanceof InvisibleNode;
 }
 
 export type ViewResolver = () => ViewClass;

--- a/nativescript-angular/element-registry.ts
+++ b/nativescript-angular/element-registry.ts
@@ -72,7 +72,7 @@ const getClassName = instance => instance.constructor.name;
 
 export interface ViewClassMeta {
     skipAddToDom?: boolean;
-    insertChild?: (parent: any, child: any, previous?: any, next?: any) => void;
+    insertChild?: (parent: any, child: any, next?: any) => void;
     removeChild?: (parent: any, child: any) => void;
 }
 

--- a/nativescript-angular/view-util.ts
+++ b/nativescript-angular/view-util.ts
@@ -67,7 +67,8 @@ export class ViewUtil {
         }
 
         if (!isDetachedElement(child)) {
-            this.addToVisualTree(parent, child, next);
+            const nextVisual = this.findNextVisual(next);
+            this.addToVisualTree(parent, child, nextVisual);
         }
     }
 
@@ -104,10 +105,10 @@ export class ViewUtil {
     }
 
     private addToVisualTree(parent: NgView, child: NgView, next: NgView): void {
-        traceLog(`ViewUtil.addToVisualTreee parent: ${parent}, view: ${child}, next: ${next}`);
+        traceLog(`ViewUtil.addToVisualTree parent: ${parent}, view: ${child}, next: ${next}`);
 
         if (parent.meta && parent.meta.insertChild) {
-            parent.meta.insertChild(parent, child);
+            parent.meta.insertChild(parent, child, next);
         } else if (isLayout(parent)) {
             this.insertToLayout(parent, child, next);
         } else if (isContentView(parent)) {
@@ -135,7 +136,7 @@ export class ViewUtil {
         }
     }
 
-    private findNextVisual(view: NgView) {
+    private findNextVisual(view: NgView): NgView {
         let next = view;
         while (next && isDetachedElement(next)) {
             next = next.nextSibling;

--- a/nativescript-angular/view-util.ts
+++ b/nativescript-angular/view-util.ts
@@ -218,7 +218,7 @@ export class ViewUtil {
     }
 
     // NOTE: This one is O(n) - use carefully
-    private getChildIndex(parent: any, child: NgView) {
+    public getChildIndex(parent: any, child: NgView) {
         if (isLayout(parent)) {
             return parent.getChildIndex(child);
         } else if (isContentView(parent)) {

--- a/nativescript-angular/view-util.ts
+++ b/nativescript-angular/view-util.ts
@@ -12,7 +12,9 @@ import {
     getViewClass,
     getViewMeta,
     isDetachedElement,
+    isInvisibleNode,
     isKnownView,
+    isView,
 } from "./element-registry";
 
 import { platformNames, Device } from "tns-core-modules/platform";
@@ -28,10 +30,6 @@ export type NgLayoutBase = LayoutBase & ViewExtensions;
 export type NgContentView = ContentView & ViewExtensions;
 export type NgPlaceholder = Placeholder & ViewExtensions;
 export type BeforeAttachAction = (view: View) => void;
-
-export function isView(view: any): view is NgView {
-    return view instanceof View;
-}
 
 export function isLayout(view: any): view is NgLayoutBase {
     return view instanceof LayoutBase;
@@ -64,7 +62,7 @@ export class ViewUtil {
 
         this.addToQueue(parent, child, previous, next);
 
-        if (child instanceof InvisibleNode) {
+        if (isInvisibleNode(child)) {
             child.templateParent = parent;
         }
 


### PR DESCRIPTION
- refactor(renderer): invoke removeFromQueue for every element
- refactor(action-bar): insert ActionItems at correct positions
ActionBar's insertChild method is now passed a `next` view argument. When the view to insert is an ActionItem, `next` is used to find the correct position to insert the new item.

- refactor(renderer): patch every View with ViewExtensions
When a View is passed through the renderer on insert/remove it's patched
with ViewExtensions for its class. That is done for parent views and for
child views.

fixes #689, fixes #978