### PR TITLE
feat(Http): Expand support for request on local files

### DIFF
--- a/nativescript-angular/http/ns-http.ts
+++ b/nativescript-angular/http/ns-http.ts
@@ -2,6 +2,7 @@ import { Injectable } from "@angular/core";
 import {
     Http,
     ConnectionBackend,
+    Request,
     RequestOptions,
     RequestOptionsArgs,
     ResponseOptions,
@@ -25,31 +26,58 @@ export class NSHttp extends Http {
   }
 
   /**
+   * Performs a request with `request` http method.
+   */
+  request(req: string | Request, options?: RequestOptionsArgs): Observable<Response> {
+    const urlString = typeof req === "string" ? req : req.url;
+    if (isLocalRequest(urlString)) {
+      return this._requestLocalUrl(urlString);
+    } else {
+      return super.request(req, options);
+    }
+  }
+
+  /**
    * Performs a request with `get` http method.
-   * Uses a local file if `~/` resource is requested.
    */
   get(url: string, options?: RequestOptionsArgs): Observable<Response> {
-    if (url.indexOf("~") === 0 || url.indexOf("/") === 0) {
-      // normalize url
-      url = url.replace("~", "").replace("/", "");
-      // request from local app resources
-      return Observable.fromPromise<Response>(new Promise((resolve, reject) => {
-        let app = this.nsFileSystem.currentApp();
-        let localFile = app.getFile(url);
-        if (localFile) {
-          localFile.readText().then((data) => {
-            resolve(responseOptions(data, 200, url));
-          }, (err: Object) => {
-            reject(responseOptions(err, 400, url));
-          });
-        } else {
-          reject(responseOptions("Not Found", 404, url));
-        }
-      }));
+    if (isLocalRequest(url)) {
+      return this._requestLocalUrl(url);
     } else {
       return super.get(url, options);
     }
   }
+
+  /**
+   * Uses a local file if `~/` resource is requested.
+   * @param url
+   */
+  private _requestLocalUrl(url: string): Observable<Response> {
+    // normalize url
+    url = normalizeLocalUrl(url);
+    // request from local app resources
+    return Observable.fromPromise<Response>(new Promise((resolve, reject) => {
+      let app = this.nsFileSystem.currentApp();
+      let localFile = app.getFile(url);
+      if (localFile) {
+        localFile.readText().then((data) => {
+          resolve(responseOptions(data, 200, url));
+        }, (err: Object) => {
+          reject(responseOptions(err, 400, url));
+        });
+      } else {
+        reject(responseOptions("Not Found", 404, url));
+      }
+    }));
+  }
+}
+
+function isLocalRequest(url: string): boolean {
+  return url.indexOf("~") === 0 || url.indexOf("/") === 0;
+}
+
+function normalizeLocalUrl(url: string): string {
+  return url.replace("~", "").replace("/", "");
 }
 
 function responseOptions(body: string | Object, status: number, url: string): Response {

--- a/tests/app/tests/http.ts
+++ b/tests/app/tests/http.ts
@@ -5,7 +5,7 @@ import {
     inject,
 } from "@angular/core/testing";
 import {ReflectiveInjector} from "@angular/core";
-import {BaseRequestOptions, ConnectionBackend, Http, Response, ResponseOptions} from "@angular/http";
+import {Request, BaseRequestOptions, ConnectionBackend, Http, Response, ResponseOptions} from "@angular/http";
 import "rxjs/add/operator/map";
 import {MockBackend} from "@angular/http/testing";
 import {NSHttp} from "nativescript-angular/http/ns-http";
@@ -40,6 +40,25 @@ describe("Http", () => {
 
     it("should work with local files prefixed with '~'", () => {
         http.get("~/test.json").map(res => res.json()).subscribe((response: any) => {
+            assert.strictEqual(3, response.length);
+            assert.strictEqual("Alex", response[0].name);
+        });
+    });
+
+    it("request method should work with local files prefixed with '~'", () => {
+        http.request("~/test.json").map(res => res.json()).subscribe((response: any) => {
+            assert.strictEqual(3, response.length);
+            assert.strictEqual("Alex", response[0].name);
+        });
+    });
+
+    it("request method using Request type should work with local files prefixed with '~'", () => {
+        const url = "~/test.json";
+        const req = new Request({
+            method: 'GET',
+            url
+        });
+        http.request(req).map(res => res.json()).subscribe((response: any) => {
             assert.strictEqual(3, response.length);
             assert.strictEqual("Alex", response[0].name);
         });


### PR DESCRIPTION
This expands support to load local app files when using Angular's `Http` core `request` method. Many apps use the basic `request` api to construct their api calls. This allows the local file request initially implemented [here](https://github.com/NativeScript/nativescript-angular/pull/286) to work the same for calls to `request`.
