### PR TITLE
fix(forms): disable onTouch for date, number and selectedIndex value accessors

### DIFF
--- a/nativescript-angular/value-accessors/date-value-accessor.ts
+++ b/nativescript-angular/value-accessors/date-value-accessor.ts
@@ -25,7 +25,6 @@ const DATE_VALUE_ACCESSOR = {
         "date-picker[ngModel],date-picker[formControlName],date-picker[formControl]",
     providers: [DATE_VALUE_ACCESSOR],
     host: {
-        "(touch)": "onTouched()",
         "(dateChange)": "onChange($event.value)",
     },
 })

--- a/nativescript-angular/value-accessors/number-value-accessor.ts
+++ b/nativescript-angular/value-accessors/number-value-accessor.ts
@@ -24,7 +24,6 @@ const NUMBER_VALUE_ACCESSOR = {
         "slider[ngModel],slider[formControlName],slider[formControl]",
     providers: [NUMBER_VALUE_ACCESSOR],
     host: {
-        "(touch)": "onTouched()",
         "(valueChange)": "onChange($event.value)",
     },
 })

--- a/nativescript-angular/value-accessors/selectedIndex-value-accessor.ts
+++ b/nativescript-angular/value-accessors/selectedIndex-value-accessor.ts
@@ -38,7 +38,6 @@ export type SelectableView = {selectedIndex: number} & View;
         "tab-view[ngModel],tab-view[formControlName],tab-view[formControl]",
     providers: [SELECTED_INDEX_VALUE_ACCESSOR],
     host: {
-        "(touch)": "onTouched()",
         "(selectedIndexChange)": "onChange($event.value)",
     },
 })


### PR DESCRIPTION
`view-base`'s `touch` event is not suitable for triggering `ngOnTouch` states for iOS
and is causing several issues, such as overriding the change event.

related #804
related #866
fixes #887 