### PR TITLE
UI must be created before first render, drainMicroTasks when the first page is created

### DIFF
--- a/nativescript-angular/platform-common.ts
+++ b/nativescript-angular/platform-common.ts
@@ -207,16 +207,18 @@ export class NativeScriptPlatformRef extends PlatformRef {
                             reject(err);
                         }
                     });
+
+                    (<any>global).Zone.drainMicroTaskQueue();
                 });
 
                 page.on(Page.navigatingToEvent, initHandler);
 
                 return page;
-            }
+            },
+            animated: false
         };
 
         if (isReboot) {
-            navEntry.animated = false;
             navEntry.clearHistory = true;
         }
 

--- a/nativescript-angular/zone-js/dist/zone-nativescript.js
+++ b/nativescript-angular/zone-js/dist/zone-nativescript.js
@@ -616,6 +616,7 @@ var Zone$1 = (function (global) {
             _isDrainingMicrotaskQueue = false;
         }
     }
+    Zone.drainMicroTaskQueue = drainMicroTaskQueue;
     function isThenable(value) {
         return value && value.then;
     }
@@ -1576,6 +1577,7 @@ function patchEventTargetMethods(obj, addFnName, removeFnName, metaCreator) {
         return false;
     }
 }
+var originalInstanceKey = zoneSymbol('originalInstance');
 // wrap some native API on `window`
 
 


### PR DESCRIPTION
Removes the white screen displayed between the launch screen and the initial page view.
Speeds up roughly 300ms startup times for iOS with Angular.

It turns out the UI that is created on viewWillAppear is just a blank Page (we knew that!)
But then few promises resolve leading to the router navigation and building the actual page UI,
these promises are resolved on the main loop, so the iOS have the time to pass a Window layout and render the blank page.

Then, the interesting part, the iOS framework will not run a second layout immediately but will play the intro animation completely, (having 300ms idle time here) and after that run Window layout. In the SDK examples the ListView will start realising cells on that second layout pass and will consume roughly 250ms.

Draining the micro tasks in viewWillAppear will let Angular apps create the UI before the native have a chance to draw a blank screen and will not experience the 300ms. idle delay on startup.

IT IS AWESOME!!!

Now:
 1. The Angular apps for iOS are nearly as fast as vanilla.
 2. We have to figure out the best way to handle this, if we manage to make angular boot synchronously instead of draining the micro tasks it would be better. Draining the micro tasks may have side effects as executing client code (such as setImmediate, setTimeout and then-ing resolved promises) out of order.