### PR TITLE
fix: deprecate NSModuleFactoryLoader in favor of the built-in SystemJsModuleLoader

### DIFF
--- a/e2e/router/package.json
+++ b/e2e/router/package.json
@@ -6,7 +6,7 @@
   "nativescript": {
     "id": "org.nativescript.router",
     "tns-android": {
-      "version": "next"
+      "version": "3.4.0-2017-12-4-1"
     },
     "tns-ios": {
       "version": "next"
@@ -20,14 +20,14 @@
     "@angular/forms": "~5.0.0",
     "@angular/http": "~5.0.0",
     "@angular/platform-browser": "~5.0.0",
+    "@angular/platform-browser-dynamic": "~5.0.0",
     "@angular/router": "~5.0.0",
     "nativescript-angular": "file:../../nativescript-angular",
     "nativescript-intl": "^3.0.0",
     "reflect-metadata": "~0.1.8",
-    "rxjs": "^5.5.0",
+    "rxjs": "5.5.2",
     "tns-core-modules": "next",
-    "zone.js": "^0.8.4",
-    "@angular/platform-browser-dynamic": "~5.0.0"
+    "zone.js": "^0.8.4"
   },
   "devDependencies": {
     "@types/chai": "^4.0.2",

--- a/nativescript-angular/router/ns-module-factory-loader.ts
+++ b/nativescript-angular/router/ns-module-factory-loader.ts
@@ -1,66 +1,19 @@
 import {
     Compiler,
     Injectable,
-    NgModuleFactory,
-    NgModuleFactoryLoader,
+    Optional,
     SystemJsNgModuleLoader,
-    Type,
+    SystemJsNgModuleLoaderConfig,
 } from "@angular/core";
-import {
-    path as fileSystemPath,
-    knownFolders
-} from "tns-core-modules/file-system";
-
-const SEPARATOR = "#";
 
 @Injectable()
-export class NSModuleFactoryLoader implements NgModuleFactoryLoader {
-    private offlineMode: boolean;
-
+export class NSModuleFactoryLoader extends SystemJsNgModuleLoader {
     constructor(
-        private compiler: Compiler,
-        private ngModuleLoader: SystemJsNgModuleLoader,
+        compiler: Compiler,
+        @Optional() config?: SystemJsNgModuleLoaderConfig
     ) {
-        this.offlineMode = compiler instanceof Compiler;
-    }
-
-    load(path: string): Promise<NgModuleFactory<any>> {
-        return this.offlineMode ?
-            this.ngModuleLoader.load(path) :
-            this.loadAndCompile(path);
-    }
-
-    private loadAndCompile(path: string): Promise<NgModuleFactory<any>> {
-        const module = requireModule(path);
-        return Promise.resolve(this.compiler.compileModuleAsync(module));
-    }
-}
-
-function requireModule(path: string): Type<any> {
-    const {modulePath, exportName} = splitPath(path);
-
-    const loadedModule = global.require(modulePath)[exportName];
-    checkNotEmpty(loadedModule, modulePath, exportName);
-
-    return loadedModule;
-}
-
-function splitPath(path: string): {modulePath: string, exportName: string} {
-    const [relativeModulePath, exportName = "default"] = path.split(SEPARATOR);
-    const absoluteModulePath = getAbsolutePath(relativeModulePath);
-
-    return {modulePath: absoluteModulePath, exportName};
-}
-
-function getAbsolutePath(relativePath: string) {
-    const projectPath = knownFolders.currentApp().path;
-    const absolutePath = fileSystemPath.join(projectPath, relativePath);
-
-    return fileSystemPath.normalize(absolutePath);
-}
-
-function checkNotEmpty(value: any, modulePath: string, exportName: string): void {
-    if (!value) {
-        throw new Error(`Cannot find '${exportName}' in '${modulePath}'`);
+        super(compiler, config);
+        console.log(`NSModuleFactoryLoader is deprecated! ` +
+        `You no longer need to provide it as a module loader.`);
     }
 }


### PR DESCRIPTION
related to NativeScript/NativeScript@011be36

Deprecated code:

NSModuleFactoryLoader is no longer needed for {N} apps.

Before:

```
// app.module.ts

@NgModule({
    providers: [
        { provide: NgModuleFactoryLoader, useClass: NSModuleFactoryLoader }
        // ...
    ],
    // ...
})
class AppModule { }
```

After:

```
// app.module.ts

@NgModule({
    providers: [
        // ...
    ],
    // ...
})
class AppModule { }
```
