### PR TITLE
chore: add animations as peer dependency

### DIFF
--- a/nativescript-angular/bin/update-app-ng-deps
+++ b/nativescript-angular/bin/update-app-ng-deps
@@ -3,7 +3,6 @@
 const path = require("path");
 const fs = require("fs");
 
-const browserDynamicDependency = "@angular/platform-browser-dynamic";
 const binPath = __dirname;
 const pluginPath = path.dirname(binPath);
 const pluginPackageJsonPath = path.join(pluginPath, "package.json");

--- a/nativescript-angular/package.json
+++ b/nativescript-angular/package.json
@@ -44,6 +44,7 @@
   },
   "peerDependencies": {
     "@angular/platform-browser-dynamic": "~5.0.0",
+    "@angular/animations": "~5.0.0",
     "@angular/common": "~5.0.0",
     "@angular/compiler": "~5.0.0",
     "@angular/core": "~5.0.0",


### PR DESCRIPTION
The `update-app-ng-deps` script does not update *animations* because it is missing as a peer dependency.