### PR TITLE
fix(animations): provide fake document object in both AoT and JiT mode

### DIFF
--- a/nativescript-angular/platform-common.ts
+++ b/nativescript-angular/platform-common.ts
@@ -62,6 +62,13 @@ export class NativeScriptSanitizer extends Sanitizer {
     }
 }
 
+// Add a fake polyfill for the document object
+(<any>global).document = (<any>global).document || {};
+const doc = (<any>global).document;
+doc.body = Object.assign((doc.body || {}), {
+    isOverride: true,
+});
+
 export class NativeScriptDocument {
     createElement(tag: string) {
         throw new Error("NativeScriptDocument is not DOM Document. There is no createElement() method.");
@@ -71,7 +78,7 @@ export class NativeScriptDocument {
 export const COMMON_PROVIDERS = [
     defaultPageFactoryProvider,
     { provide: Sanitizer, useClass: NativeScriptSanitizer, deps: [] },
-    { provide: DOCUMENT, useClass: NativeScriptDocument, deps: [] },
+    { provide: DOCUMENT, useValue: doc },
 ];
 
 export class NativeScriptPlatformRef extends PlatformRef {

--- a/nativescript-angular/platform.ts
+++ b/nativescript-angular/platform.ts
@@ -18,7 +18,6 @@ import {
 } from "@angular/platform-browser-dynamic";
 
 import {
-    DOCUMENT,
     ɵINTERNAL_BROWSER_PLATFORM_PROVIDERS as INTERNAL_BROWSER_PLATFORM_PROVIDERS
 } from "@angular/platform-browser";
 
@@ -31,13 +30,6 @@ import {
     MissingTranslationStrategy,
     StaticProvider,
 } from "@angular/core";
-
-// Add a fake polyfill for the document object
-(<any>global).document = (<any>global).document || {};
-const doc = (<any>global).document;
-doc.body = Object.assign((doc.body || {}), {
-    isOverride: true,
-});
 
 // Work around a TS bug requiring an imports of
 // InjectionToken, ViewEncapsulation and MissingTranslationStrategy
@@ -66,10 +58,6 @@ export const NS_COMPILER_PROVIDERS: StaticProvider[] = [
             ]
         },
         multi: true
-    },
-    {
-        provide: DOCUMENT,
-        useValue: doc,
     },
 ];
 


### PR DESCRIPTION
The fake document object that is needed for the angular animations
should be provided both when using the static platform and the dynamic
one.

Can be tested with
https://github.com/nativescript/ns-ng-animation-examples.
```bash
// 1
git clone https://github.com/nativescript/ns-ng-animation-examples

// 2
tns run android --bundle --env.aot

// 3
// Navigate to the first example and expect the button to animate to
opacity 0 when tapped.
```

fixes #1163 