### PR TITLE
fix(router): Occasional crash in NSRouteReuseStrategy.shouldAttach()

### DIFF
--- a/nativescript-angular/router/ns-route-reuse-strategy.ts
+++ b/nativescript-angular/router/ns-route-reuse-strategy.ts
@@ -79,7 +79,8 @@ export class NSRouteReuseStrategy implements RouteReuseStrategy {
 
         const key = getSnapshotKey(route);
         const isBack = this.location._isPageNavigatingBack();
-        const shouldAttach = isBack && this.cache.peek().key === key;
+        const cachedItem = this.cache.peek();
+        const shouldAttach = isBack && cachedItem && cachedItem.key === key;
 
         log(`shouldAttach isBack: ${isBack} key: ${key} result: ${shouldAttach}`);
 


### PR DESCRIPTION


## PR Checklist

- [x ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ??] All existing tests are passing: https://github.com/NativeScript/nativescript-angular/blob/master/DevelopmentWorkflow.md#running-the-tests . (Uncaught ReferenceError: exports is not defined)
- [ ] Tests for the changes are included.

## What is the current behavior?
Crash when using back button, see #1048.

## What is the new behavior?
Copy the same check used in the retrieve() method into the shouldAttach() method

Fixes #1048.

