### PR TITLE
refactor: use es2015 import/exports syntax

### DIFF
--- a/nativescript-angular/tsconfig.json
+++ b/nativescript-angular/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "module": "commonjs",
+    "module": "es2015",
     "moduleResolution": "node",
     "sourceMap": true,
     "emitDecoratorMetadata": true,


### PR DESCRIPTION
That will allow UglifyJS to tree-shake the unused exports in/from the
plugin.
