### PR TITLE
fix(router): state is not guarded before use

### DIFF
--- a/nativescript-angular/router/ns-location-strategy.ts
+++ b/nativescript-angular/router/ns-location-strategy.ts
@@ -50,8 +50,12 @@ export class NSLocationStrategy extends LocationStrategy {
             return "/";
         }
 
-        let tree = this.currentUrlTree;
         const state = this.peekState(this.currentOutlet);
+        if (!state) {
+            return "/";
+        }
+
+        let tree = this.currentUrlTree;
 
         // Handle case where the user declares a component at path "/".
         // The url serializer doesn't parse this url as having a primary outlet.


### PR DESCRIPTION
`state` is not guarded before use, but `peekState` may return null.

Appears to have been introduced [here](https://github.com/NativeScript/nativescript-angular/commit/b98da83adb3f5c51ee448fa38a51b7c65274c82e#diff-a7820fa2a2eb0ce14f3f0b8bfc666dd5R49).
Before those changes, `state` was guarded.

May result in the following stack, seen on some older iOS devices (2-3 years) when rapidly navigating:
```
CONSOLE ERROR file:///app/tns_modules/@angular/core/bundles/core.umd.js:1682:24: ERROR TypeError: undefined is not an object (evaluating 'state.isPageNavigation')
CONSOLE ERROR file:///app/tns_modules/@angular/core/bundles/core.umd.js:1682:24: ERROR TypeError: undefined is not an object (evaluating 'state.isPageNavigation')
CONSOLE ERROR file:///app/tns_modules/@angular/core/bundles/core.umd.js:1682:24: ERROR Error: Uncaught (in promise): TypeError: null is not an object (evaluating 'state.isRootSegmentGroup')
path@file:///app/tns_modules/nativescript-angular/router/ns-location-strategy.js:33:18
get@file:///app/tns_modules/nativescript-angular/router/ns-platform-location.js:38:46
path@file:///app/tns_modules/@angular/common/bundles/common.umd.js:589:46
path@file:///app/tns_modules/@angular/common/bundles/common.umd.js:247:58
isCurrentPathEqualTo@file:///app/tns_modules/@angular/common/bundles/common.umd.js:260:25
file:///app/tns_modules/@angular/router/bundles/router.umd.js:4158:56
file:///app/tns_modules/rxjs/internal/Observable.js:203:25
__tryOrUnsub@file:///app/tns_modules/rxjs/internal/Subscriber.js:263:20
next@file:///app/tns_modules/rxjs/internal/Subscriber.js:201:34
_next@file:///app/tns_modules/rxjs/internal/Subscriber.js:139:30
next@file:///app/tns_modules/rxjs/internal/Subscriber.js:103:23
_next@file:///app/tns_module
```