### PR TITLE
fix(router): avoiding throw for app stability improvements

### DIFF
--- a/nativescript-angular/router/ns-location-strategy.ts
+++ b/nativescript-angular/router/ns-location-strategy.ts
@@ -1,7 +1,7 @@
 import { Injectable } from "@angular/core";
 import { LocationStrategy } from "@angular/common";
 import { DefaultUrlSerializer, UrlSegmentGroup, UrlTree } from "@angular/router";
-import { routerLog } from "../trace";
+import { routerLog, routerError } from "../trace";
 import { NavigationTransition, Frame } from "tns-core-modules/ui/frame";
 import { isPresent } from "../lang-facade";
 import { FrameService } from "../platform-providers";
@@ -286,10 +286,11 @@ export class NSLocationStrategy extends LocationStrategy {
 
     // Methods for syncing with page navigation in PageRouterOutlet
     public _beginBackPageNavigation(name: string, frame: Frame) {
-        routerLog("NSLocationStrategy.startGoBack()");
         if (this._isPageNavigationBack) {
-            throw new Error("Calling startGoBack while going back.");
+            routerError("Attempted to call startGoBack while going back.");
+            return;
         }
+        routerLog("NSLocationStrategy.startGoBack()");
         this._isPageNavigationBack = true;
 
         let { cachedFrame } = this.frameService.findFrame(frame);
@@ -302,10 +303,11 @@ export class NSLocationStrategy extends LocationStrategy {
     }
 
     public _finishBackPageNavigation() {
-        routerLog("NSLocationStrategy.finishBackPageNavigation()");
         if (!this._isPageNavigationBack) {
-            throw new Error("Calling endGoBack while not going back.");
+            routerError("Attempted to call endGoBack while not going back.");
+            return;
         }
+        routerLog("NSLocationStrategy.finishBackPageNavigation()");
         this._isPageNavigationBack = false;
     }
 
@@ -314,33 +316,35 @@ export class NSLocationStrategy extends LocationStrategy {
     }
 
     public _beginModalNavigation(frame: Frame): void {
-        routerLog("NSLocationStrategy._beginModalNavigation()");
+      routerLog("NSLocationStrategy._beginModalNavigation()");
 
-        let { cachedFrameRootOutlet } = this.frameService.findFrame(frame);
+      let { cachedFrameRootOutlet } = this.frameService.findFrame(frame);
 
-        const lastState = this.peekState(cachedFrameRootOutlet || this.currentOutlet);
+      const lastState = this.peekState(cachedFrameRootOutlet || this.currentOutlet);
 
-        if (lastState) {
-            lastState.isModalNavigation = true;
-        }
+      if (lastState) {
+          lastState.isModalNavigation = true;
+      }
 
-        this._isModalNavigation = true;
-    }
+      this._isModalNavigation = true;
+  }
 
     public _beginCloseModalNavigation(): void {
-        routerLog("NSLocationStrategy.startCloseModal()");
         if (this._isModalClosing) {
-            throw new Error("Calling startCloseModal while closing modal.");
+            routerError("Attempted to call startCloseModal while closing modal.");
+            return;
         }
+        routerLog("NSLocationStrategy.startCloseModal()");
         this._isModalClosing = true;
     }
 
     public _finishCloseModalNavigation() {
-        routerLog("NSLocationStrategy.finishCloseModalNavigation()");
         if (!this._isModalClosing) {
-            throw new Error("Calling startCloseModal while not closing modal.");
+            routerError("Attempted to call startCloseModal while not closing modal.");
+            return;
         }
 
+        routerLog("NSLocationStrategy.finishCloseModalNavigation()");
         this._isModalNavigation = false;
         this._isModalClosing = false;
     }

--- a/nativescript-angular/router/page-router-outlet.ts
+++ b/nativescript-angular/router/page-router-outlet.ts
@@ -238,7 +238,8 @@ export class PageRouterOutlet implements OnDestroy { // tslint:disable-line:dire
         resolver: ComponentFactoryResolver | null): void {
 
         if (this.locationStrategy._isPageNavigatingBack()) {
-            log("Currently in page back navigation - component should be reattached instead of activated. " + routeTransitionWarning);
+            log("Currently in page back navigation - component should be reattached instead of activated. " + 
+                routeTransitionWarning);
             this.locationStrategy._finishBackPageNavigation();
         }
 

--- a/nativescript-angular/router/page-router-outlet.ts
+++ b/nativescript-angular/router/page-router-outlet.ts
@@ -102,8 +102,6 @@ function routeToString(activatedRoute: ActivatedRoute | ActivatedRouteSnapshot):
     return activatedRoute.pathFromRoot.join("->");
 }
 
-const routeTransitionWarning = "This could be due to route transition timing and could be ignored.";
-
 @Directive({ selector: "page-router-outlet" }) // tslint:disable-line:directive-selector
 export class PageRouterOutlet implements OnDestroy { // tslint:disable-line:directive-class-suffix
     private activated: ComponentRef<any> | null = null;
@@ -177,8 +175,7 @@ export class PageRouterOutlet implements OnDestroy { // tslint:disable-line:dire
 
     deactivate(): void {
         if (!this.locationStrategy._isPageNavigatingBack()) {
-          log("Currently not in page back navigation" +
-            " - component should be detached instead of deactivated." + routeTransitionWarning);
+          log("Currently not in page back navigation - component should be detached instead of deactivated.");
           return;
         }
 
@@ -238,8 +235,7 @@ export class PageRouterOutlet implements OnDestroy { // tslint:disable-line:dire
         resolver: ComponentFactoryResolver | null): void {
 
         if (this.locationStrategy._isPageNavigatingBack()) {
-            log("Currently in page back navigation - component should be reattached instead of activated. " +
-                routeTransitionWarning);
+            log("Currently in page back navigation - component should be reattached instead of activated.");
             this.locationStrategy._finishBackPageNavigation();
         }
 

--- a/nativescript-angular/router/page-router-outlet.ts
+++ b/nativescript-angular/router/page-router-outlet.ts
@@ -102,6 +102,8 @@ function routeToString(activatedRoute: ActivatedRoute | ActivatedRouteSnapshot):
     return activatedRoute.pathFromRoot.join("->");
 }
 
+const routeTransitionWarning = "This could be due to route transition timing and could be ignored.";
+
 @Directive({ selector: "page-router-outlet" }) // tslint:disable-line:directive-selector
 export class PageRouterOutlet implements OnDestroy { // tslint:disable-line:directive-class-suffix
     private activated: ComponentRef<any> | null = null;
@@ -126,14 +128,16 @@ export class PageRouterOutlet implements OnDestroy { // tslint:disable-line:dire
 
     get component(): Object {
         if (!this.activated) {
-            throw new Error("Outlet is not activated");
+            log("Outlet is not activated");
+            return;
         }
 
         return this.activated.instance;
     }
     get activatedRoute(): ActivatedRoute {
         if (!this.activated) {
-            throw new Error("Outlet is not activated");
+            log("Outlet is not activated");
+            return;
         }
 
         return this._activatedRoute;
@@ -173,8 +177,9 @@ export class PageRouterOutlet implements OnDestroy { // tslint:disable-line:dire
 
     deactivate(): void {
         if (!this.locationStrategy._isPageNavigatingBack()) {
-            throw new Error("Currently not in page back navigation" +
-                " - component should be detached instead of deactivated.");
+          log("Currently not in page back navigation" +
+            " - component should be detached instead of deactivated." + routeTransitionWarning);
+          return;
         }
 
         log("PageRouterOutlet.deactivate() while going back - should destroy");
@@ -197,7 +202,8 @@ export class PageRouterOutlet implements OnDestroy { // tslint:disable-line:dire
      */
     detach(): ComponentRef<any> {
         if (!this.isActivated) {
-            throw new Error("Outlet is not activated");
+            log("Outlet is not activated");
+            return;
         }
 
         log("PageRouterOutlet.detach() - " + routeToString(this._activatedRoute));
@@ -232,7 +238,8 @@ export class PageRouterOutlet implements OnDestroy { // tslint:disable-line:dire
         resolver: ComponentFactoryResolver | null): void {
 
         if (this.locationStrategy._isPageNavigatingBack()) {
-            throw new Error("Currently in page back navigation - component should be reattached instead of activated.");
+            log("Currently in page back navigation - component should be reattached instead of activated. " + routeTransitionWarning);
+            this.locationStrategy._finishBackPageNavigation();
         }
 
         log("PageRouterOutlet.activateWith() - " + routeToString(activatedRoute));

--- a/nativescript-angular/router/page-router-outlet.ts
+++ b/nativescript-angular/router/page-router-outlet.ts
@@ -238,7 +238,7 @@ export class PageRouterOutlet implements OnDestroy { // tslint:disable-line:dire
         resolver: ComponentFactoryResolver | null): void {
 
         if (this.locationStrategy._isPageNavigatingBack()) {
-            log("Currently in page back navigation - component should be reattached instead of activated. " + 
+            log("Currently in page back navigation - component should be reattached instead of activated. " +
                 routeTransitionWarning);
             this.locationStrategy._finishBackPageNavigation();
         }

--- a/nativescript-angular/trace.ts
+++ b/nativescript-angular/trace.ts
@@ -28,6 +28,10 @@ export function routerLog(message: string): void {
     write(message, routerTraceCategory);
 }
 
+export function routerError(message: string): void {
+    write(message, routerTraceCategory, messageType.error);
+}
+
 export function routeReuseStrategyLog(message: string): void {
     write(message, routeReuseStrategyTraceCategory);
 }


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-angular/blob/master/DevelopmentWorkflow.md#running-the-tests
- [ ] Tests for the changes are included.

## What is the current behavior?

During normal usage of a NativeScript app a user can experience instability and unresponsiveness while navigating around an app. This is often experienced when monkeying around as users enjoy doing with mobile apps. Due to extraneous usage of `throw` throughout router handling, this monkeying around of a {N} app would eventually cause one of these `throw`'s to trigger and throwing the app into unstable state and other times just simply crash.

## What is the new behavior?

Developers can now properly commence a deep dive debugging sessions by turning tracing on to investigate various UX flows to find suitable fixes within their own apps.


