### PR TITLE
fix(modal): lower isModalNavigation flag when closing modal

### DIFF
--- a/nativescript-angular/router/ns-location-strategy.ts
+++ b/nativescript-angular/router/ns-location-strategy.ts
@@ -328,6 +328,8 @@ export class NSLocationStrategy extends LocationStrategy {
         if (!this._isModalClosing) {
             throw new Error("Calling startCloseModal while not closing modal.");
         }
+
+        this._isModalNavigation = false;
         this._isModalClosing = false;
     }
 


### PR DESCRIPTION
`_isModalNavigation` should be set to `false` when closing modal view. 

_Note: `_isModalNavigation` is used to mark a state (cached in `cacheByOutlet` dictionary) as the beginning of a navigation inside modal view.  Currently we are lowering this flag only when caching states (navigating further). If there is no further navigation inside the modal view the `_isModalNavigation` will remain `true` which will disturb the clearing of the cached states later on._
