### PR TITLE
 fix(dialogs): unable to show nested frameless modal views

### DIFF
--- a/e2e/modal-navigation-ng/app/modal/modal.component.html
+++ b/e2e/modal-navigation-ng/app/modal/modal.component.html
@@ -6,7 +6,7 @@
     <StackLayout backgroundColor="lightGreen">
         <Button text="Navigate To Second Page" (tap)="onNavigateSecondPage()" [visibility]="navigationVisibility"></Button>
         <Button text="Show Nested Modal Page With Frame" (tap)="showNestedModalFrame()" [visibility]="navigationVisibility"></Button>
-        <Button text="Show Nested Modal Page" (tap)="showNestedModal()" [visibility]="navigationVisibility"></Button>
+        <Button text="Show Nested Modal Page" (tap)="showNestedModal()"></Button>
         <Button text="Show Dialog" (tap)="showDialogConfirm()"></Button>
         <Button text="Close Modal" (tap)="close(rootLayout)"></Button>
     </StackLayout>

--- a/e2e/modal-navigation-ng/e2e/modal-layout.e2e-spec.ts
+++ b/e2e/modal-navigation-ng/e2e/modal-layout.e2e-spec.ts
@@ -45,6 +45,10 @@ describe("modal-layout:", () => {
                 await screen.loadedHome();
             });
 
+            it("should show nested modal page, run in background, close", async () => {
+                await testNestedModalPageBackground(driver, screen, false);
+            });
+
             it("should show dialog confirm inside modal view with no frame, run in background", async () => {
                 await testDialogBackground(driver, screen, false);
             });

--- a/nativescript-angular/directives/dialogs.ts
+++ b/nativescript-angular/directives/dialogs.ts
@@ -67,6 +67,9 @@ export class ModalDialogService {
             parentView = parentView.ngAppRoot;
         }
 
+        // _ngDialogRoot is the first child of the previously detached proxy.
+        // It should have 'viewController' (iOS) or '_dialogFragment' (Android) available for
+        // presenting future modal views.
         if (parentView._ngDialogRoot) {
             parentView = parentView._ngDialogRoot;
         }

--- a/nativescript-angular/directives/dialogs.ts
+++ b/nativescript-angular/directives/dialogs.ts
@@ -67,6 +67,10 @@ export class ModalDialogService {
             parentView = parentView.ngAppRoot;
         }
 
+        if (parentView._ngDialogRoot) {
+            parentView = parentView._ngDialogRoot;
+        }
+
         const pageFactory: PageFactory = viewContainerRef.injector.get(PAGE_FACTORY);
 
         // resolve from particular module (moduleRef)
@@ -76,7 +80,9 @@ export class ModalDialogService {
 
         const frame = parentView.page && parentView.page.frame;
 
-        this.location._beginModalNavigation(frame);
+        if (frame) {
+            this.location._beginModalNavigation(frame);
+        }
 
         return new Promise((resolve, reject) => {
             setTimeout(() => {
@@ -144,6 +150,7 @@ export class ModalDialogService {
             componentView = detachedProxy.getChildAt(0);
 
             if (componentView.parent) {
+                (<any>componentView.parent)._ngDialogRoot = componentView;
                 (<any>componentView.parent).removeChild(componentView);
             }
 

--- a/tests/app/tests/ns-location-strategy.ts
+++ b/tests/app/tests/ns-location-strategy.ts
@@ -36,7 +36,7 @@ export class FakeFrame extends View implements Frame {
         }
     }
 
-    navigate(entry: any) {}
+    navigate(entry: any) { }
 
     constructor(private backCB?: () => void) {
         super();
@@ -70,8 +70,13 @@ export class FakeFrame extends View implements Frame {
     _findEntryForTag(fragmentTag: string): BackstackEntry {
         throw new Error("I am a FakeFrame");
     }
-
     _updateBackstack(entry: BackstackEntry, isBack: boolean): void {
+        throw new Error("I am a FakeFrame");
+    }
+    _pushInFrameStack() {
+        throw new Error("I am a FakeFrame");
+    }
+    _removeFromFrameStack() {
         throw new Error("I am a FakeFrame");
     }
 }


### PR DESCRIPTION
__The problem__: Unable to show modal from another modal if they are not presented from `<p-r-o>` (frameless). There is no available `viewController` (iOS) from whom we can present future modal view.

__The solution__: Use previous modal child view as a `parentView` when presenting new modal. The child view a.k.a `_ngDialogRoot` should have available `viewController` (iOS) created from the previous  modal presentation.

 - __modal-navigation-ng__ tests added

Fix: https://github.com/NativeScript/NativeScript/issues/5924
