### PR TITLE
fix(frame-service): move FrameService provider to NativeScriptModule

### DIFF
--- a/e2e/single-page/package.json
+++ b/e2e/single-page/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@angular/compiler-cli": "~6.1.0",
-    "@ngtools/webpack": "~6.1.0",
+    "@ngtools/webpack": "~6.2.0-beta.3",
     "@types/chai": "^4.0.2",
     "@types/mocha": "^2.2.41",
     "@types/node": "^7.0.5",

--- a/nativescript-angular/common.ts
+++ b/nativescript-angular/common.ts
@@ -12,7 +12,6 @@ import {
     defaultDeviceProvider,
     defaultFrameProvider,
     defaultPageProvider,
-    FrameService,
 } from "./platform-providers";
 import { NS_DIRECTIVES } from "./directives";
 
@@ -26,7 +25,6 @@ import { NS_DIRECTIVES } from "./directives";
         defaultDeviceProvider,
         defaultFrameProvider,
         defaultPageProvider,
-        FrameService,
     ],
     imports: [
         CommonModule,

--- a/nativescript-angular/nativescript.module.ts
+++ b/nativescript-angular/nativescript.module.ts
@@ -28,6 +28,7 @@ import { NativeScriptCommonModule } from "./common";
 import { NativeScriptRendererFactory } from "./renderer";
 import { DetachedLoader } from "./common/detached-loader";
 import { throwIfAlreadyLoaded } from "./common/utils";
+import { FrameService } from "./platform-providers";
 
 export function errorHandlerFactory() {
     return new ErrorHandler();
@@ -38,6 +39,7 @@ export function errorHandlerFactory() {
         DetachedLoader,
     ],
     providers: [
+        FrameService,
         NativeScriptRendererFactory,
         SystemJsNgModuleLoader,
         { provide: APP_ROOT, useValue: true },


### PR DESCRIPTION
FrameService provider is not singleton when provided through `NativeScriptCommonModule` (since it is imported for every single module in lazy loaded app).

Moving FrameService to `NativeScriptModule` in order to be singleton since it is not stateless (holding cached frames collection).

Fix https://github.com/NativeScript/nativescript-angular/issues/1484
