### PR TITLE
fix: Import reflect-metadata(needed in JIT mode) before @angular

### DIFF
--- a/nativescript-angular/platform.ts
+++ b/nativescript-angular/platform.ts
@@ -1,4 +1,4 @@
-// Always reflect-metadata before @angular/core.
+// Always import reflect-metadata before @angular/core.
 // It's needed to handle __metadata calls inside @angular/core
 import "reflect-metadata";
 

--- a/nativescript-angular/platform.ts
+++ b/nativescript-angular/platform.ts
@@ -1,12 +1,14 @@
-// Always import platform-common first - because polyfills
+// Always reflect-metadata before @angular/core.
+// It's needed to handle __metadata calls inside @angular/core
+import "reflect-metadata";
+
+// Import platform-common immediately after reflect-metadata - because rest of the polyfills.
 import {
     NativeScriptPlatformRef,
     AppOptions,
     PlatformFactory,
     COMMON_PROVIDERS
 } from "./platform-common";
-
-import "reflect-metadata";
 
 import { NSFileSystem } from "./file-system/ns-file-system";
 
@@ -49,7 +51,7 @@ export const NS_COMPILER_PROVIDERS: StaticProvider[] = [
         provide: COMPILER_OPTIONS,
         useValue: {
             providers: [
-                { provide: NSFileSystem, deps: []},
+                { provide: NSFileSystem, deps: [] },
                 { provide: ResourceLoader, useClass: FileSystemResourceLoader, deps: [NSFileSystem] },
                 { provide: ElementSchemaRegistry, useClass: NativeScriptElementSchemaRegistry, deps: [] },
             ]


### PR DESCRIPTION
`reflect-metadata` is need in JIT mode and needs to be imported before `@angular\core`. It contains calls to `__metadata` and other methods that rely on global `Reflect` to be defined.

Related to #1454