### PR TITLE
fix(tabview): prevent white flash on tab changes

### DIFF
--- a/nativescript-angular/directives/tab-view.ts
+++ b/nativescript-angular/directives/tab-view.ts
@@ -8,7 +8,7 @@ import {
     ViewContainerRef,
 } from "@angular/core";
 import { TabView, TabViewItem } from "tns-core-modules/ui/tab-view";
-import { TextTransform  } from "tns-core-modules/ui/text-base";
+import { TextTransform, Color } from "tns-core-modules/ui/text-base";
 
 import { InvisibleNode } from "../element-registry";
 import { rendererLog, isLogEnabled } from "../trace";
@@ -145,7 +145,8 @@ export class TabViewItemDirective implements OnInit {
 
         if (realViews.length > 0) {
             this.item.view = realViews[0];
-
+            // prevent white flash on tab changes
+            this.item.view.backgroundColor = new Color('#00000000');
             const newItems = (this.owner.tabView.items || []).concat([this.item]);
             this.owner.tabView.items = newItems;
         }


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-angular/blob/master/DevelopmentWorkflow.md#running-the-tests
- [ ] Tests for the changes are included.

## What is the current behavior?

White flash occurs on iOS and Android when tabview's change.

## What is the new behavior?

White flash will no longer occur when switching tabs on Android.
iOS requires few more changes - see comment [here](https://github.com/NativeScript/NativeScript/issues/6454#issuecomment-433176056). Since the changes to complete for iOS are debateable I will let the debate continue on that suggestion until we reach conclusion before submitting further PR's to complete for iOS which needs changes in core modules as well.

closes https://github.com/NativeScript/NativeScript/issues/6454

Also addresses https://github.com/NativeScript/nativescript-angular/issues/1351#issuecomment-431625862