### PR TITLE
fix(location-strategy): crash when back on named lazy loaded outlet

### DIFF
--- a/nativescript-angular/router/page-router-outlet.ts
+++ b/nativescript-angular/router/page-router-outlet.ts
@@ -391,7 +391,7 @@ export class PageRouterOutlet implements OnDestroy { // tslint:disable-line:dire
             let outletKeyForRoute = this.locationStrategy.getRouteFullPath(nodeToMark);
             let outlet = this.locationStrategy.findOutletByKey(outletKeyForRoute);
 
-            if (outlet && outlet.frame) {
+            if (outlet && outlet.frames.length) {
                 nodeToMark[pageRouterActivatedSymbol] = true;
                 if (isLogEnabled()) {
                     log("Activated route marked as page: " + routeToString(nodeToMark));

--- a/tests/app/tests/modal-dialog.ts
+++ b/tests/app/tests/modal-dialog.ts
@@ -97,7 +97,7 @@ describe("modal-dialog", () => {
 
                 let parentView = fixture.componentRef.instance.vcRef.element.nativeElement;
                 parentView = parentView.page && parentView.page.frame;
-                outlet.frame = parentView;
+                outlet.frames.push(parentView);
                 locStrategy._getOutlets().push(outlet);
 
                 locStrategy.pushState(null, "test", "/test", null);
@@ -119,7 +119,7 @@ describe("modal-dialog", () => {
 
                 let parentView = fixture.componentRef.instance.vcRef.element.nativeElement;
                 parentView = parentView.page && parentView.page.frame;
-                outlet.frame = parentView;
+                outlet.frames.push(parentView);
                 locStrategy._getOutlets().push(outlet);
 
                 locStrategy.pushState(null, "test", "/test", null);

--- a/tests/app/tests/ns-location-strategy.ts
+++ b/tests/app/tests/ns-location-strategy.ts
@@ -143,7 +143,7 @@ function simulatePageNavigation(strategy: NSLocationStrategy, url: string, frame
     strategy.pushState(null, null, url, null);
 
     const outlet: Outlet = strategy.findOutletByOutletPath(outletName);
-    outlet.frame = frame;
+    outlet.frames.push(frame);
     strategy._beginPageNavigation(frame);
 }
 


### PR DESCRIPTION
Outlet could be represented by multiple frames when its named and lazy loaded. 
`.goBack()` should be called on the innermost frame (the last one from the collection of outlet frames)

_Note: Every nested named lazy loaded outlet should be wrapped in `NSEmptyOutletComponent` (which is just a regular `<page-router-outlet`>)_