### PR TITLE
fix(page-router-outlet): actionBarVisibility not applied

### DIFF
--- a/nativescript-angular/router/ns-empty-outlet.component.ts
+++ b/nativescript-angular/router/ns-empty-outlet.component.ts
@@ -1,5 +1,6 @@
-import { Component } from "@angular/core";
+import { Component, ViewChild } from "@angular/core";
 import { Page } from "tns-core-modules/ui/page";
+import { PageRouterOutlet } from "./page-router-outlet";
 @Component({
     // tslint:disable-next-line:component-selector
     selector: "ns-empty-outlet",
@@ -7,9 +8,16 @@ import { Page } from "tns-core-modules/ui/page";
     template: "<page-router-outlet isEmptyOutlet='true'></page-router-outlet>"
 })
 export class NSEmptyOutletComponent {
+    @ViewChild(PageRouterOutlet) pageRouterOutlet: PageRouterOutlet;
     constructor(private page: Page) {
         if (this.page) {
             this.page.actionBarHidden = true;
+
+            this.page.on("loaded", () => {
+                if (this.pageRouterOutlet && this.page.frame) {
+                    this.pageRouterOutlet.setActionBarVisibility(this.page.frame.actionBarVisibility);
+                }
+            });
         }
     }
 }


### PR DESCRIPTION
`actionBarVisibility` property has no effect when applied to nested lazy loaded named outlet.

NSEmptyOutlet `<page-router-outlet>` should inherit its parent frame `actionBarVisibility`