### PR TITLE
fix(location-strategy): extend support for nested primary outlets

### DIFF
--- a/e2e/nested-router-tab-view/app/app.component.html
+++ b/e2e/nested-router-tab-view/app/app.component.html
@@ -1,1 +1,1 @@
-<page-router-outlet></page-router-outlet>
+<page-router-outlet tag="rootPRO"></page-router-outlet>

--- a/e2e/nested-router-tab-view/app/app.routing.ts
+++ b/e2e/nested-router-tab-view/app/app.routing.ts
@@ -49,6 +49,10 @@ const routes: Routes = [
         loadChildren: "./home-lazy/home-lazy.module#HomeLazyModule",
     },
     {
+        path: "custom-tabs",
+        loadChildren: "./custom-tabs/custom-tabs.module#CustomTabsModule",
+    },
+    {
         path: "tabs", component: TabsComponent, children: [
             { path: "players", component: PlayerComponent, outlet: "playerTab" },
             { path: "player/:id", component: PlayerDetailComponent, outlet: "playerTab" },

--- a/e2e/nested-router-tab-view/app/custom-tabs/custom-tabs.component.html
+++ b/e2e/nested-router-tab-view/app/custom-tabs/custom-tabs.component.html
@@ -1,0 +1,19 @@
+<ActionBar title="Custom Tabs Component" class="action-bar">
+    <NavigationButton text="Root Back"></NavigationButton>
+
+    <StackLayout orientation="horizontal">
+        <Button horizontalAlignment="left" android:visibility="visible" ios:visibility="collapse" text="Root Back" (tap)="onRootBack()"></Button>
+        <Label horizontalAlignment="center" text="Custom Tabs Component"></Label>
+    </StackLayout>
+</ActionBar>
+
+<GridLayout rows="50,*, auto">
+    <!-- <Button row="0" text="CanGoBack(ParentRoute)" automationText="CanGoBack(ParentRoute)" col="3" (tap)="canGoBackParentRoute()"></Button> -->
+    <GridLayout row="1">
+        <page-router-outlet tag="customTabsPRO"></page-router-outlet>
+    </GridLayout>
+    <GridLayout row="2" columns="*, *">
+        <Button col="0" text="Players Tab" [nsRouterLink]="['../tabs/players']"></Button>
+        <Button col="1" text="Teams Tab" [nsRouterLink]="['../tabs/teams']"></Button>
+    </GridLayout>
+</GridLayout>

--- a/e2e/nested-router-tab-view/app/custom-tabs/custom-tabs.component.ts
+++ b/e2e/nested-router-tab-view/app/custom-tabs/custom-tabs.component.ts
@@ -1,0 +1,44 @@
+import { Component, OnInit } from '@angular/core';
+import { ModalDialogService, ModalDialogOptions } from "nativescript-angular/directives/dialogs";
+import { RouterExtensions } from "nativescript-angular/router";
+import { ActivatedRoute } from "@angular/router";
+import { confirm } from "tns-core-modules/ui/dialogs";
+import { Page } from 'tns-core-modules/ui/page/page';
+
+@Component({
+  moduleId: module.id,
+  selector: 'custom-tabs',
+  templateUrl: './custom-tabs.component.html'
+})
+export class CustomTabsComponent implements OnInit {
+
+  constructor(
+    private activeRoute: ActivatedRoute,
+    private routerExtension: RouterExtensions,
+    private page: Page) { }
+
+  ngOnInit() {
+  }
+
+  canGoBackParentRoute() {
+    const canGoBackParentRoute = this.routerExtension.canGoBack({ relativeTo: this.activeRoute });
+    const title = "CanGoBack(ParentRoute)";
+    this.onShowDialog(title, title + ` ${canGoBackParentRoute}`);
+  }
+
+  onRootBack() {
+    this.page.frame.goBack();
+  }
+
+  onShowDialog(title: string, result: string) {
+    let options: any = {
+      title: title,
+      message: result,
+      okButtonText: "Ok"
+    }
+
+    confirm(options).then((result: boolean) => {
+      console.log(result);
+    })
+  }
+}

--- a/e2e/nested-router-tab-view/app/custom-tabs/custom-tabs.module.ts
+++ b/e2e/nested-router-tab-view/app/custom-tabs/custom-tabs.module.ts
@@ -1,0 +1,38 @@
+import { NgModule, NO_ERRORS_SCHEMA } from '@angular/core';
+import { NativeScriptCommonModule } from 'nativescript-angular/common';
+import { NativeScriptRouterModule } from 'nativescript-angular/router';
+
+import { CustomTabsComponent } from './custom-tabs.component';
+import { PlayerComponent } from "../player/players.component";
+import { PlayerDetailComponent } from "../player/player-detail.component";
+import { TeamsComponent } from "../team/teams.component";
+import { TeamDetailComponent } from "../team/team-detail.component";
+import { Route } from "@angular/router";
+import { SharedModule } from "../shared.module";
+
+const routes: Route[] = [
+  {
+    path: 'tabs',
+    component: CustomTabsComponent,
+    children: [
+      { path: "players", component: PlayerComponent },
+      { path: "player/:id", component: PlayerDetailComponent },
+
+      { path: "teams", component: TeamsComponent },
+      { path: "team/:id", component: TeamDetailComponent },
+    ]
+  },
+];
+
+@NgModule({
+  declarations: [CustomTabsComponent
+  ],
+  imports: [
+    NativeScriptCommonModule,
+    NativeScriptRouterModule,
+    NativeScriptRouterModule.forChild(routes),
+    SharedModule
+  ],
+  schemas: [NO_ERRORS_SCHEMA]
+})
+export class CustomTabsModule { }

--- a/e2e/nested-router-tab-view/app/login/login.component.html
+++ b/e2e/nested-router-tab-view/app/login/login.component.html
@@ -3,7 +3,7 @@
 </ActionBar>
 
 <StackLayout>
-    <!-- <Button text="Go To Home Page" [nsRouterLink]="['/home', { outlets: { playerTab: ['players'], teamTab: ['teams'] } }]"></Button> -->
     <Button text="Go To Home Page" [nsRouterLink]="['../home', { outlets: { playerTab: ['players'], teamTab: ['teams'] } }]"></Button>
     <Button text="Go To Lazy Home Page" [nsRouterLink]="['../home-lazy/home', { outlets: { playerTab: ['players'], teamTab: ['teams'] } }]"></Button>
+    <Button text="Go To Lazy Custom Tabs" [nsRouterLink]="['../custom-tabs/tabs/players']"></Button>
 </StackLayout> 

--- a/e2e/nested-router-tab-view/app/player/player-detail.component.html
+++ b/e2e/nested-router-tab-view/app/player/player-detail.component.html
@@ -1,4 +1,6 @@
-<ActionBar title="Player Details" class="action-bar"></ActionBar>
+<ActionBar title="Player Details" class="action-bar">
+    <!-- <NavigationButton visibility="hidden"></NavigationButton> -->
+</ActionBar>
 <StackLayout flexDirection="column" class="page" class="m-15">
     <Label [text]="item.id"></Label>
     <Label [text]="item.name + ' Details'"></Label>

--- a/e2e/nested-router-tab-view/app/player/players.component.html
+++ b/e2e/nested-router-tab-view/app/player/players.component.html
@@ -1,11 +1,11 @@
-<ActionBar title="Player List" class="action-bar"></ActionBar>
+<ActionBar title="Player List" class="action-bar">
+    <!-- <NavigationButton visibility="hidden"></NavigationButton> -->
+</ActionBar>
 
-<GridLayout>
-    <!-- <Button text="Open Named Modal" (tap)="onModalFrame()"></Button> -->
-    <ListView [items]="items" class="list-group">
+<GridLayout rows="auto,*">
+    <ListView row="1" [items]="items" class="list-group">
         <ng-template let-item="item">
-            <Label [nsRouterLink]="['../player', item.id]" [text]="item.name"
-                class="list-group-item"></Label>
+            <Label [nsRouterLink]="['../player', item.id]" [text]="item.name" class="list-group-item"></Label>
         </ng-template>
     </ListView>
 </GridLayout>

--- a/e2e/nested-router-tab-view/app/player/players.component.ts
+++ b/e2e/nested-router-tab-view/app/player/players.component.ts
@@ -1,6 +1,5 @@
 import { Component, OnInit, ViewContainerRef } from "@angular/core";
 import { DataService, DataItem } from "../data.service";
-import { RouterExtensions } from "nativescript-angular/router";
 
 import { ModalDialogService, ModalDialogOptions } from "nativescript-angular/directives/dialogs";
 import { ModalRouterComponent } from "../modal/modal-router/modal-router.component";
@@ -12,7 +11,10 @@ import { ModalRouterComponent } from "../modal/modal-router/modal-router.compone
 export class PlayerComponent implements OnInit {
     items: DataItem[];
 
-    constructor(private modal: ModalDialogService, private itemService: DataService, private router: RouterExtensions, private vcRef: ViewContainerRef, ) { }
+    constructor(
+        private modal: ModalDialogService,
+        private itemService: DataService,
+        private vcRef: ViewContainerRef, ) { }
 
     ngOnInit(): void {
         this.items = this.itemService.getPlayers();

--- a/e2e/nested-router-tab-view/app/team/team-detail.component.html
+++ b/e2e/nested-router-tab-view/app/team/team-detail.component.html
@@ -1,4 +1,6 @@
-<ActionBar title="Team Details" class="action-bar"></ActionBar>
+<ActionBar title="Team Details" class="action-bar">
+    <!-- <NavigationButton visibility="hidden"></NavigationButton> -->
+</ActionBar>
 <StackLayout flexDirection="column" class="page" class="m-15">
     <Label [text]="item.id"></Label>
     <Label [text]="item.name + ' Details'"></Label>

--- a/e2e/nested-router-tab-view/app/team/teams.component.html
+++ b/e2e/nested-router-tab-view/app/team/teams.component.html
@@ -1,4 +1,6 @@
-<ActionBar title="Team List" class="action-bar"></ActionBar>
+<ActionBar title="Team List" class="action-bar">
+    <!-- <NavigationButton visibility="hidden"></NavigationButton> -->
+</ActionBar>
 
 <GridLayout>
     <ListView [items]="items" class="list-group">

--- a/e2e/nested-router-tab-view/e2e/custom-tabs.e2e-spec.ts
+++ b/e2e/nested-router-tab-view/e2e/custom-tabs.e2e-spec.ts
@@ -1,0 +1,72 @@
+import { AppiumDriver, createDriver } from "nativescript-dev-appium";
+import { Screen } from "./screen"
+import {
+    testPlayerNavigated,
+    testTeamNavigated,
+    testPlayerNextNavigated,
+    testTeamNextNavigated,
+} from "./shared.e2e-spec"
+
+describe("custom-tabs:", () => {
+    let driver: AppiumDriver;
+    let screen: Screen;
+
+    before(async () => {
+        driver = await createDriver();
+        screen = new Screen(driver);
+    });
+
+    after(async () => {
+        await driver.quit();
+        console.log("Quit driver!");
+    });
+
+    afterEach(async function () {
+        if (this.currentTest.state === "failed") {
+            await driver.logTestArtifacts(this.currentTest.title);
+        }
+    });
+
+    it("loaded custom tab component and tabs", async () => {
+        await screen.navigateCustomTabsPage();
+        await screen.loadedCustomTabsPage();
+        await screen.loadedPlayersList();
+        await gotoTeamsTab(driver);
+        await screen.loadedTeamList();
+    });
+
+    it("navigate back to login and again to custom tabs", async () => {
+        await backRoot(driver);
+        await screen.loadedLogin();
+        await screen.navigateCustomTabsPage();
+        await screen.loadedCustomTabsPage();
+        await screen.loadedPlayersList();
+        await gotoTeamsTab(driver);
+        await screen.loadedTeamList();
+    });
+
+    it("navigate back to login and again to custom tabs", async () => {
+        await gotoPlayersTab(driver);
+        await testPlayerNavigated(screen, screen.playerOne);
+        await gotoTeamsTab(driver);
+        await screen.loadedTeamList();
+        await testTeamNavigated(screen, screen.teamOne);
+        await backRoot(driver);
+        await screen.loadedLogin();
+    });
+});
+
+async function backRoot(driver: AppiumDriver) {
+    const btnBackRoot = await driver.findElementByAutomationText("Root Back");
+    await btnBackRoot.tap();
+}
+
+async function gotoPlayersTab(driver: AppiumDriver) {
+    const btnTabTeams = await driver.findElementByAutomationText("Players Tab");
+    await btnTabTeams.tap();
+}
+
+async function gotoTeamsTab(driver: AppiumDriver) {
+    const btnTabTeams = await driver.findElementByAutomationText("Teams Tab");
+    await btnTabTeams.tap();
+}

--- a/e2e/nested-router-tab-view/e2e/screen.ts
+++ b/e2e/nested-router-tab-view/e2e/screen.ts
@@ -1,6 +1,7 @@
 import { AppiumDriver, SearchOptions } from "nativescript-dev-appium";
 import { assert } from "chai";
 
+const customTabs = "Custom Tabs Component";
 const home = "Home Component";
 const about = "About Component";
 const aboutNested = "Nested About Component";
@@ -18,6 +19,7 @@ const gotoNextTeam = "next team";
 const gotoTeams = "teams";
 
 const gotoHomePage = "Go To Home Page";
+const gotoCustomTabPage = "Go To Lazy Custom Tabs";
 const gotoAboutPage = "Go To About Page";
 const gotoTabsPage = "Go To Tabs Page";
 const confirmDialog = "Ok";
@@ -65,6 +67,12 @@ export class Screen {
     loadedHome = async () => {
         const lblHome = await this._driver.findElementByAutomationText(home);
         assert.isTrue(await lblHome.isDisplayed());
+        console.log(home + " loaded!");
+    }
+
+    loadedCustomTabsPage= async () => {
+        const lblCustomTabs = await this._driver.findElementByAutomationText(customTabs);
+        assert.isTrue(await lblCustomTabs.isDisplayed());
         console.log(home + " loaded!");
     }
 
@@ -125,6 +133,11 @@ export class Screen {
 
     navigateToHomePage = async (homePageButton?) => {
         const btnNavToHomePage = await this._driver.findElementByAutomationText(homePageButton || gotoHomePage);
+        await btnNavToHomePage.tap();
+    }
+
+    navigateCustomTabsPage = async () => {
+        const btnNavToHomePage = await this._driver.findElementByAutomationText(gotoCustomTabPage);
         await btnNavToHomePage.tap();
     }
 

--- a/nativescript-angular/router/ns-location-strategy.ts
+++ b/nativescript-angular/router/ns-location-strategy.ts
@@ -249,7 +249,7 @@ export class NSLocationStrategy extends LocationStrategy {
             let count = 1;
 
             if (frame) {
-                while (state.frame !== frame) {
+                while (state.frame && state.frame !== frame) {
                     state = states.pop();
                     count++;
                 }
@@ -463,7 +463,7 @@ export class NSLocationStrategy extends LocationStrategy {
         }
 
         if (!outlet.containsFrame(frame)) {
-                        outlet.frames.push(frame);
+            outlet.frames.push(frame);
         }
         this.currentOutlet = outlet;
     }

--- a/nativescript-angular/router/ns-location-strategy.ts
+++ b/nativescript-angular/router/ns-location-strategy.ts
@@ -1,6 +1,6 @@
 import { Injectable } from "@angular/core";
 import { LocationStrategy } from "@angular/common";
-import { DefaultUrlSerializer, UrlSegmentGroup, UrlTree } from "@angular/router";
+import { DefaultUrlSerializer, UrlSegmentGroup, UrlTree, ActivatedRouteSnapshot } from "@angular/router";
 import { routerLog, routerError, isLogEnabled } from "../trace";
 import { NavigationTransition, Frame } from "tns-core-modules/ui/frame";
 import { isPresent } from "../lang-facade";
@@ -88,6 +88,7 @@ export interface LocationState {
     segmentGroup: UrlSegmentGroup;
     isRootSegmentGroup: boolean;
     isPageNavigation: boolean;
+    frame?: Frame;
 }
 
 @Injectable()
@@ -162,7 +163,7 @@ export class NSLocationStrategy extends LocationStrategy {
         if (!Object.keys(urlTreeRoot.children).length) {
             const segmentGroup = this.currentUrlTree && this.currentUrlTree.root;
             const outletKey = this.getOutletKey(this.getSegmentGroupFullPath(segmentGroup), "primary");
-            const outlet = this.findOutletByKey(outletKey);
+            const outlet = this.findOutlet(outletKey);
 
             if (outlet && this.updateStates(outlet, segmentGroup)) {
                 this.currentOutlet = outlet; // If states updated
@@ -186,12 +187,12 @@ export class NSLocationStrategy extends LocationStrategy {
 
                 const outletPath = this.getSegmentGroupFullPath(currentTree);
                 let outletKey = this.getOutletKey(outletPath, outletName);
-                let outlet = this.findOutletByKey(outletKey);
+                let outlet = this.findOutlet(outletKey);
 
                 const parentOutletName = currentTree.outlet || "";
                 const parentOutletPath = this.getSegmentGroupFullPath(currentTree.parent);
                 const parentOutletKey = this.getOutletKey(parentOutletPath, parentOutletName);
-                const parentOutlet = this.findOutletByKey(parentOutletKey);
+                const parentOutlet = this.findOutlet(parentOutletKey);
 
                 const containsLastState = outlet && outlet.containsTopState(currentSegmentGroup.toString());
                 if (!outlet) {
@@ -237,7 +238,7 @@ export class NSLocationStrategy extends LocationStrategy {
         throw new Error("NSLocationStrategy.forward() - not implemented");
     }
 
-    back(outlet?: Outlet): void {
+    back(outlet?: Outlet, frame?: Frame): void {
         this.currentOutlet = outlet || this.currentOutlet;
 
         if (this.currentOutlet.isPageNavigationBack) {
@@ -246,6 +247,13 @@ export class NSLocationStrategy extends LocationStrategy {
             // clear the stack until we get to a page navigation state
             let state = states.pop();
             let count = 1;
+
+            if (frame) {
+                while (state.frame !== frame) {
+                    state = states.pop();
+                    count++;
+                }
+            }
 
             while (!state.isPageNavigation) {
                 state = states.pop();
@@ -447,9 +455,15 @@ export class NSLocationStrategy extends LocationStrategy {
         return this.outlets;
     }
 
-    updateOutletFrame(outlet: Outlet, frame: Frame) {
+    updateOutletFrame(outlet: Outlet, frame: Frame, isEmptyOutletFrame: boolean) {
+        const lastState = outlet.peekState();
+
+        if (lastState && !lastState.frame && !isEmptyOutletFrame) {
+            lastState.frame = frame;
+        }
+
         if (!outlet.containsFrame(frame)) {
-            outlet.frames.push(frame);
+                        outlet.frames.push(frame);
         }
         this.currentOutlet = outlet;
     }
@@ -547,12 +561,17 @@ export class NSLocationStrategy extends LocationStrategy {
         });
     }
 
-    findOutletByOutletPath(pathByOutlets: string): Outlet {
-        return this.outlets.find((outlet) => outlet.pathByOutlets === pathByOutlets);
-    }
+    findOutlet(outletKey: string, activatedRouteSnapshot?: ActivatedRouteSnapshot): Outlet {
+        let outlet: Outlet = this.outlets.find((currentOutlet) => currentOutlet.outletKeys.indexOf(outletKey) > -1);
 
-    findOutletByKey(outletKey: string): Outlet {
-        return this.outlets.find((outlet) => outlet.outletKeys.indexOf(outletKey) > -1);
+        // No Outlet with the given outletKey could happen when using nested unnamed p-r-o
+        // primary -> primary -> prymary
+        if (!outlet && activatedRouteSnapshot) {
+            const pathByOutlets = this.getPathByOutlets(activatedRouteSnapshot);
+            outlet = this.outlets.find((currentOutlet) => currentOutlet.pathByOutlets === pathByOutlets);
+        }
+
+        return outlet;
     }
 
     private getOutletByFrame(frame: Frame): Outlet {

--- a/nativescript-angular/router/ns-route-reuse-strategy.ts
+++ b/nativescript-angular/router/ns-route-reuse-strategy.ts
@@ -100,7 +100,7 @@ export class NSRouteReuseStrategy implements RouteReuseStrategy {
         route = findTopActivatedRouteNodeForOutlet(route);
 
         const outletKey = this.location.getRouteFullPath(route);
-        const outlet = this.location.findOutletByKey(outletKey);
+        const outlet = this.location.findOutlet(outletKey, route);
         const key = getSnapshotKey(route);
         const isPageActivated = route[pageRouterActivatedSymbol];
         const isBack = outlet ? outlet.isPageNavigationBack : false;
@@ -125,7 +125,7 @@ export class NSRouteReuseStrategy implements RouteReuseStrategy {
         route = findTopActivatedRouteNodeForOutlet(route);
 
         const outletKey = this.location.getRouteFullPath(route);
-        const outlet = this.location.findOutletByKey(outletKey);
+        const outlet = this.location.findOutlet(outletKey, route);
         const cache = this.cacheByOutlet[outletKey];
         if (!cache) {
             return false;
@@ -185,7 +185,7 @@ export class NSRouteReuseStrategy implements RouteReuseStrategy {
         route = findTopActivatedRouteNodeForOutlet(route);
 
         const outletKey = this.location.getRouteFullPath(route);
-        const outlet = this.location.findOutletByKey(outletKey);
+        const outlet = this.location.findOutlet(outletKey, route);
         const cache = this.cacheByOutlet[outletKey];
         if (!cache) {
             return null;

--- a/nativescript-angular/router/page-router-outlet.ts
+++ b/nativescript-angular/router/page-router-outlet.ts
@@ -287,7 +287,7 @@ export class PageRouterOutlet implements OnDestroy { // tslint:disable-line:dire
         }
 
         this.outlet.isNSEmptyOutlet = this.isEmptyOutlet;
-        this.locationStrategy.updateOutletFrame(this.outlet, this.frame);
+        this.locationStrategy.updateOutletFrame(this.outlet, this.frame, this.isEmptyOutlet);
 
         if (this.outlet && this.outlet.isPageNavigationBack) {
             if (isLogEnabled()) {
@@ -355,7 +355,7 @@ export class PageRouterOutlet implements OnDestroy { // tslint:disable-line:dire
         page.on(Page.navigatedFromEvent, (<any>global).Zone.current.wrap((args: NavigatedData) => {
             if (args.isBackNavigation) {
                 this.locationStrategy._beginBackPageNavigation(this.frame);
-                this.locationStrategy.back();
+                this.locationStrategy.back(null, this.frame);
             }
         }));
 
@@ -394,14 +394,14 @@ export class PageRouterOutlet implements OnDestroy { // tslint:disable-line:dire
                 queue.push(childRoute);
             });
 
-            const nodeToMark = findTopActivatedRouteNodeForOutlet(currentRoute);
-            let outletKeyForRoute = this.locationStrategy.getRouteFullPath(nodeToMark);
-            let outlet = this.locationStrategy.findOutletByKey(outletKeyForRoute);
+            const topActivatedRoute = findTopActivatedRouteNodeForOutlet(currentRoute);
+            let outletKey = this.locationStrategy.getRouteFullPath(topActivatedRoute);
+            let outlet = this.locationStrategy.findOutlet(outletKey, topActivatedRoute);
 
             if (outlet && outlet.frames.length) {
-                nodeToMark[pageRouterActivatedSymbol] = true;
+                topActivatedRoute[pageRouterActivatedSymbol] = true;
                 if (isLogEnabled()) {
-                    log("Activated route marked as page: " + routeToString(nodeToMark));
+                    log("Activated route marked as page: " + routeToString(topActivatedRoute));
                 }
             }
 
@@ -429,20 +429,17 @@ export class PageRouterOutlet implements OnDestroy { // tslint:disable-line:dire
         if (modalNavigation > 0) { // Modal with 'primary' p-r-o
             outlet = this.locationStrategy.findOutletByModal(modalNavigation);
         } else {
-            outlet = this.locationStrategy.findOutletByKey(outletKey);
+            outlet = this.locationStrategy.findOutlet(outletKey, topActivatedRoute);
         }
 
         // Named lazy loaded outlet.
         if (!outlet && this.isEmptyOutlet) {
             const parentOutletKey = this.locationStrategy.getRouteFullPath(topActivatedRoute.parent);
-            outlet = this.locationStrategy.findOutletByKey(parentOutletKey);
+            outlet = this.locationStrategy.findOutlet(parentOutletKey, topActivatedRoute.parent);
 
             if (outlet) {
                 outlet.outletKeys.push(outletKey);
             }
-        } else if (!outlet) {
-            const pathByOutlets = this.locationStrategy.getPathByOutlets(topActivatedRoute);
-            outlet = this.locationStrategy.findOutletByOutletPath(pathByOutlets);
         }
 
         return outlet;

--- a/nativescript-angular/router/router-extensions.ts
+++ b/nativescript-angular/router/router-extensions.ts
@@ -126,7 +126,7 @@ export class RouterExtensions {
 
         const currentRouteSnapshop = findTopActivatedRouteNodeForOutlet(currentRoute.snapshot);
         const outletKey = this.locationStrategy.getRouteFullPath(currentRouteSnapshop);
-        outlet = this.locationStrategy.findOutletByKey(outletKey);
+        outlet = this.locationStrategy.findOutlet(outletKey, currentRouteSnapshop);
 
         return outlet;
     }

--- a/tests/app/tests/ns-location-strategy.ts
+++ b/tests/app/tests/ns-location-strategy.ts
@@ -142,7 +142,7 @@ function simulatePageNavigation(strategy: NSLocationStrategy, url: string, frame
     outletName = outletName || "primary";
     strategy.pushState(null, null, url, null);
 
-    const outlet: Outlet = strategy.findOutletByOutletPath(outletName);
+    const outlet: Outlet = strategy.findOutlet(outletName);
     outlet.frames.push(frame);
     strategy._beginPageNavigation(frame);
 }
@@ -281,7 +281,7 @@ describe("NSLocationStrategy", () => {
         strategy.pushState(null, null, "/internal", null);
         expectedStates.push(createState("/internal", outletName));
 
-        const outlet: Outlet = strategy.findOutletByOutletPath(outletName);
+        const outlet: Outlet = strategy.findOutlet(outletName);
 
         assertStatesEqual(outlet.states, expectedStates);
     });
@@ -306,8 +306,8 @@ describe("NSLocationStrategy", () => {
         strategy.pushState(null, null, "/(test1:internal//test2:test2)", null);
         expectedStatesTest1.push(createState("/(test1:internal//test2:test2)", outletName));
 
-        const outlet: Outlet = strategy.findOutletByOutletPath(outletName);
-        const outlet2: Outlet = strategy.findOutletByOutletPath(outletName2);
+        const outlet: Outlet = strategy.findOutlet(outletName);
+        const outlet2: Outlet = strategy.findOutlet(outletName2);
 
         assertStatesEqual(outlet.states, expectedStatesTest1);
         assertStatesEqual(outlet2.states, expectedStatesTest2);
@@ -329,7 +329,7 @@ describe("NSLocationStrategy", () => {
         });
 
         simulatePageNavigation(strategy, "/page", currentFrame, outletName);
-        const outlet: Outlet = strategy.findOutletByOutletPath(outletName);
+        const outlet: Outlet = strategy.findOutlet(outletName);
 
         assert.equal(frameBackCount, 0);
         assert.equal(popCount, 0);
@@ -360,8 +360,8 @@ describe("NSLocationStrategy", () => {
         const currentFrame = frameService.getFrame();
         simulatePageNavigation(strategy, "/(test1:page//test2:test2)", frame, outletName);
         simulatePageNavigation(strategy, "/(test1:page//test2:test2)", currentFrame, outletName2);
-        const outlet: Outlet = strategy.findOutletByOutletPath(outletName);
-        const outlet2: Outlet = strategy.findOutletByOutletPath(outletName2);
+        const outlet: Outlet = strategy.findOutlet(outletName);
+        const outlet2: Outlet = strategy.findOutlet(outletName2);
 
         assert.equal(frameBackCount, 0);
         assert.equal(popCount, 0);
@@ -392,7 +392,7 @@ describe("NSLocationStrategy", () => {
         });
 
         simulatePageNavigation(strategy, "/page", currentFrame, outletName);
-        const outlet: Outlet = strategy.findOutletByOutletPath(outletName);
+        const outlet: Outlet = strategy.findOutlet(outletName);
 
         assert.equal(frameBackCount, 0);
         assert.equal(popCount, 0);
@@ -424,8 +424,8 @@ describe("NSLocationStrategy", () => {
 
         simulatePageNavigation(strategy, "/(test1:page//test2:test2)", frame, outletName);
         simulatePageNavigation(strategy, "/(test1:page//test2:test2)", frame2, outletName2);
-        const outlet: Outlet = strategy.findOutletByOutletPath(outletName);
-        const outlet2: Outlet = strategy.findOutletByOutletPath(outletName2);
+        const outlet: Outlet = strategy.findOutlet(outletName);
+        const outlet2: Outlet = strategy.findOutlet(outletName2);
 
         assert.equal(frameBackCount, 0);
         assert.equal(popCount, 0);
@@ -449,7 +449,7 @@ describe("NSLocationStrategy", () => {
         // Act
         strategy._setNavigationOptions({ clearHistory: true });
         simulatePageNavigation(strategy, "/cleared", frame, outletName);
-        const outlet: Outlet = strategy.findOutletByOutletPath(outletName);
+        const outlet: Outlet = strategy.findOutlet(outletName);
         // Assert
         assertStatesEqual(outlet.states, [createState("/cleared", outletName, true)]);
     });
@@ -472,8 +472,8 @@ describe("NSLocationStrategy", () => {
             createState("/(test1:cleared//test2:test2)", outletName2, true)
         ];
 
-        const outlet: Outlet = strategy.findOutletByOutletPath(outletName);
-        const outlet2: Outlet = strategy.findOutletByOutletPath(outletName2);
+        const outlet: Outlet = strategy.findOutlet(outletName);
+        const outlet2: Outlet = strategy.findOutlet(outletName2);
 
         // Assert
         assertStatesEqual(outlet.states, expectedStatesTest1);


### PR DESCRIPTION
Extending `LocationState` with `Frame` property which holds the `Frame` that initiated the navigation for the  given `LocationState`. __Back__ in parent Outlet should take care of its children states (remove all states until the current `Frame` that goes back is reached).

Various bug with nested primary `<page-router-outlets>` where reported from both Kinvey Shared Application and the North Star project.
