### PR TITLE
fix(NativeScriptPlatformRef): Destroy lastModuleRef on exitEvent

### DIFF
--- a/nativescript-angular/platform-common.ts
+++ b/nativescript-angular/platform-common.ts
@@ -34,6 +34,7 @@ import {
     launchEvent,
     LaunchEventData,
     exitEvent,
+    ApplicationEventData,
 } from "tns-core-modules/application";
 import { TextView } from "tns-core-modules/ui/text-view";
 
@@ -257,9 +258,16 @@ export class NativeScriptPlatformRef extends PlatformRef {
             }
         );
         const exitCallback = profile(
-            "nativescript-angular/platform-common.exitCallback", () => {
+            "nativescript-angular/platform-common.exitCallback", (args: ApplicationEventData) => {
+                const androidActivity = args.android;
+                if (androidActivity && !androidActivity.isFinishing()) {
+                    // Exit event was triggered as a part of a restart of the app.
+                    return;
+                }
+
                 const lastModuleRef = lastBootstrappedModule ? lastBootstrappedModule.get() : null;
                 if (lastModuleRef) {
+                    // Make sure the module is only destroyed once
                     lastBootstrappedModule = null;
 
                     lastModuleRef.destroy();

--- a/nativescript-angular/platform-common.ts
+++ b/nativescript-angular/platform-common.ts
@@ -257,7 +257,7 @@ export class NativeScriptPlatformRef extends PlatformRef {
             }
         );
         const exitCallback = profile(
-            "nativescript-angular/platform-common.exitCallback",() => {
+            "nativescript-angular/platform-common.exitCallback", () => {
                 const lastModuleRef = lastBootstrappedModule ? lastBootstrappedModule.get() : null;
                 if (lastModuleRef) {
                     lastModuleRef.destroy();

--- a/nativescript-angular/platform-common.ts
+++ b/nativescript-angular/platform-common.ts
@@ -260,6 +260,8 @@ export class NativeScriptPlatformRef extends PlatformRef {
             "nativescript-angular/platform-common.exitCallback", () => {
                 const lastModuleRef = lastBootstrappedModule ? lastBootstrappedModule.get() : null;
                 if (lastModuleRef) {
+                    lastBootstrappedModule = null;
+
                     lastModuleRef.destroy();
                 }
 

--- a/nativescript-angular/platform-common.ts
+++ b/nativescript-angular/platform-common.ts
@@ -262,6 +262,10 @@ export class NativeScriptPlatformRef extends PlatformRef {
                 if (lastModuleRef) {
                     lastModuleRef.destroy();
                 }
+
+                if (!autoCreateFrame) {
+                    rootContent = null;
+                }
             }
         );
         on(launchEvent, launchCallback);

--- a/nativescript-angular/platform-common.ts
+++ b/nativescript-angular/platform-common.ts
@@ -33,6 +33,7 @@ import {
     on,
     launchEvent,
     LaunchEventData,
+    exitEvent,
 } from "tns-core-modules/application";
 import { TextView } from "tns-core-modules/ui/text-view";
 
@@ -255,7 +256,16 @@ export class NativeScriptPlatformRef extends PlatformRef {
                 args.root = rootContent;
             }
         );
+        const exitCallback = profile(
+            "nativescript-angular/platform-common.exitCallback",() => {
+                const lastModuleRef = lastBootstrappedModule ? lastBootstrappedModule.get() : null;
+                if (lastModuleRef) {
+                    lastModuleRef.destroy();
+                }
+            }
+        );
         on(launchEvent, launchCallback);
+        on(exitEvent, exitCallback);
 
         applicationRun();
     }

--- a/nativescript-angular/router/page-router-outlet.ts
+++ b/nativescript-angular/router/page-router-outlet.ts
@@ -352,12 +352,19 @@ export class PageRouterOutlet implements OnDestroy { // tslint:disable-line:dire
         // Add it to the new page
         page.content = componentView;
 
-        page.on(Page.navigatedFromEvent, (<any>global).Zone.current.wrap((args: NavigatedData) => {
+        const navigatedFromCallback = (<any>global).Zone.current.wrap((args: NavigatedData) => {
             if (args.isBackNavigation) {
                 this.locationStrategy._beginBackPageNavigation(this.frame);
                 this.locationStrategy.back(null, this.frame);
             }
-        }));
+        });
+        page.on(Page.navigatedFromEvent, navigatedFromCallback);
+        componentRef.onDestroy(() => {
+            if (page) {
+                page.off(Page.navigatedFromEvent, navigatedFromCallback);
+                page = null;
+            }
+        });
 
         const navOptions = this.locationStrategy._beginPageNavigation(this.frame);
 
@@ -374,7 +381,9 @@ export class PageRouterOutlet implements OnDestroy { // tslint:disable-line:dire
         }
 
         this.frame.navigate({
-            create: () => { return page; },
+            create() {
+                return page;
+            },
             clearHistory: navOptions.clearHistory,
             animated: navOptions.animated,
             transition: navOptions.transition

--- a/nativescript-angular/router/page-router-outlet.ts
+++ b/nativescript-angular/router/page-router-outlet.ts
@@ -374,10 +374,9 @@ export class PageRouterOutlet implements OnDestroy { // tslint:disable-line:dire
                 if (this.outlet) {
                     this.routeReuseStrategy.clearCache(this.outlet.outletKeys[0]);
                 }
-                page.off(Page.navigatedToEvent, clearCallback);
             });
 
-            page.on(Page.navigatedToEvent, clearCallback);
+            page.once(Page.navigatedToEvent, clearCallback);
         }
 
         this.frame.navigate({


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-angular/blob/master/DevelopmentWorkflow.md#running-the-tests
- ~Tests for the changes are included.~ **Don't see how**

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The application module isn't destroyed when the application exitEvent is triggered.
This causes the previous instance of the nativescript-angular app to be running in a sleep state and `ngOnDestroy()` on it's compoments, services etc. are not called as expected.

## What is the new behavior?
Adds an event listener for the `exitEvent` in the `NativeScriptPlatformRef` which destroys the `lastModuleRef` which triggers `ngOnDestroy()` as expected.

Fixes #923 



<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

