### PR TITLE
fix(router): routing services should be provided in forRoot only

### DIFF
--- a/nativescript-angular/router/router.module.ts
+++ b/nativescript-angular/router/router.module.ts
@@ -19,32 +19,41 @@ export { NSEmptyOutletComponent } from "./ns-empty-outlet.component";
 
 export type LocationState = LocationState;
 
+const ROUTER_DIRECTIVES = [NSRouterLink, NSRouterLinkActive, PageRouterOutlet, NSEmptyOutletComponent];
+
+const NS_ROUTER_PROVIDERS = [
+    {
+        provide: NSLocationStrategy,
+        useFactory: provideLocationStrategy,
+        deps: [[NSLocationStrategy, new Optional(), new SkipSelf()], FrameService],
+    },
+    { provide: LocationStrategy, useExisting: NSLocationStrategy },
+    NativescriptPlatformLocation,
+    { provide: PlatformLocation, useClass: NativescriptPlatformLocation },
+    RouterExtensions,
+    NSRouteReuseStrategy,
+    { provide: RouteReuseStrategy, useExisting: NSRouteReuseStrategy },
+];
+
 @NgModule({
-    declarations: [NSRouterLink, NSRouterLinkActive, PageRouterOutlet, NSEmptyOutletComponent],
-    providers: [
-        {
-            provide: NSLocationStrategy,
-            useFactory: provideLocationStrategy,
-            deps: [[NSLocationStrategy, new Optional(), new SkipSelf()], FrameService],
-        },
-        { provide: LocationStrategy, useExisting: NSLocationStrategy },
-        NativescriptPlatformLocation,
-        { provide: PlatformLocation, useClass: NativescriptPlatformLocation },
-        RouterExtensions,
-        NSRouteReuseStrategy,
-        { provide: RouteReuseStrategy, useExisting: NSRouteReuseStrategy },
-    ],
+    declarations: ROUTER_DIRECTIVES,
+    entryComponents: [NSEmptyOutletComponent],
     imports: [RouterModule, NativeScriptCommonModule],
-    exports: [RouterModule, NSRouterLink, NSRouterLinkActive, PageRouterOutlet, NSEmptyOutletComponent],
+    exports: [RouterModule, ...ROUTER_DIRECTIVES],
     schemas: [NO_ERRORS_SCHEMA],
 })
 export class NativeScriptRouterModule {
-    static forRoot(routes: Routes, config?: ExtraOptions): ModuleWithProviders {
-        return RouterModule.forRoot(routes, config);
+    static forRoot(routes: Routes, config?: ExtraOptions): ModuleWithProviders<NativeScriptRouterModule> {
+        const ngForRoot: ModuleWithProviders = RouterModule.forRoot(routes, config);
+        return {
+            ngModule: NativeScriptRouterModule,
+            providers: [...ngForRoot.providers, ...NS_ROUTER_PROVIDERS]
+        };
     }
 
-    static forChild(routes: Routes): ModuleWithProviders {
-        return RouterModule.forChild(routes);
+    static forChild(routes: Routes): ModuleWithProviders<NativeScriptRouterModule> {
+        const ngForChild: ModuleWithProviders = RouterModule.forChild(routes);
+        return { ngModule: NativeScriptRouterModule, providers: ngForChild.providers };
     }
 }
 

--- a/nativescript-angular/router/router.module.ts
+++ b/nativescript-angular/router/router.module.ts
@@ -44,16 +44,14 @@ const NS_ROUTER_PROVIDERS = [
 })
 export class NativeScriptRouterModule {
     static forRoot(routes: Routes, config?: ExtraOptions): ModuleWithProviders<NativeScriptRouterModule> {
-        const ngForRoot: ModuleWithProviders = RouterModule.forRoot(routes, config);
         return {
             ngModule: NativeScriptRouterModule,
-            providers: [...ngForRoot.providers, ...NS_ROUTER_PROVIDERS]
+            providers: [...RouterModule.forRoot(routes, config).providers, ...NS_ROUTER_PROVIDERS]
         };
     }
 
     static forChild(routes: Routes): ModuleWithProviders<NativeScriptRouterModule> {
-        const ngForChild: ModuleWithProviders = RouterModule.forChild(routes);
-        return { ngModule: NativeScriptRouterModule, providers: ngForChild.providers };
+        return { ngModule: NativeScriptRouterModule, providers: RouterModule.forChild(routes).providers };
     }
 }
 

--- a/tests/app/tests/router-module-tests.ts
+++ b/tests/app/tests/router-module-tests.ts
@@ -29,9 +29,6 @@ describe("NativeScriptRouterModule.forRoot", () => {
     it("should provide nativescript routing services", () => {
         return nsTestBedRender(RouterTestComponent).then((fixture) => {
             const injector = fixture.componentRef.injector
-            let ls = injector.get(LocationStrategy, null);
-            console.log("----> ls: " + typeof ls);
-            console.dir(ls);
 
             assert.instanceOf(injector.get(LocationStrategy, null), NSLocationStrategy);
             assert.instanceOf(injector.get(RouterExtensions, null), RouterExtensions);

--- a/tests/app/tests/router-module-tests.ts
+++ b/tests/app/tests/router-module-tests.ts
@@ -1,0 +1,77 @@
+// make sure you import mocha-config before @angular/core
+import { Component, ViewChild } from "@angular/core";
+import { nsTestBedAfterEach, nsTestBedBeforeEach, nsTestBedRender } from "nativescript-angular/testing";
+import { NativeScriptRouterModule, RouterExtensions } from "nativescript-angular/router";
+import { NSRouterLink } from "nativescript-angular/router/ns-router-link";
+import { NSLocationStrategy } from "nativescript-angular/router/ns-location-strategy";
+import { assert } from "~/tests/test-config";
+import { ActivatedRoute, Router, RouteReuseStrategy } from "@angular/router";
+import { LocationStrategy, PlatformLocation } from "@angular/common";
+import { NSRouteReuseStrategy } from "nativescript-angular/router/ns-route-reuse-strategy";
+
+@Component({
+    template: `<StackLayout><Label nsRouterLink text="COMPONENT"></Label></StackLayout>`
+})
+class RouterTestComponent {
+    @ViewChild(NSRouterLink)
+    nsRouterLink: NSRouterLink;
+}
+
+describe("NativeScriptRouterModule.forRoot", () => {
+    beforeEach(nsTestBedBeforeEach(
+        [RouterTestComponent],
+        [],
+        [NativeScriptRouterModule.forRoot([])],
+        []));
+
+    afterEach(nsTestBedAfterEach());
+
+    it("should provide nativescript routing services", () => {
+        return nsTestBedRender(RouterTestComponent).then((fixture) => {
+            const injector = fixture.componentRef.injector
+            let ls = injector.get(LocationStrategy, null);
+            console.log("----> ls: " + typeof ls);
+            console.dir(ls);
+
+            assert.instanceOf(injector.get(LocationStrategy, null), NSLocationStrategy);
+            assert.instanceOf(injector.get(RouterExtensions, null), RouterExtensions);
+            assert.instanceOf(injector.get(RouteReuseStrategy, null), NSRouteReuseStrategy);
+        });
+    });
+
+    it("should provide nativescript routing directives", () => {
+        return nsTestBedRender(RouterTestComponent).then((fixture) => {
+            const linkDirective = fixture.componentRef.instance.nsRouterLink;
+            assert.instanceOf(linkDirective, NSRouterLink);
+        });
+    });
+});
+
+describe("NativeScriptRouterModule.forChild", () => {
+    beforeEach(nsTestBedBeforeEach(
+        [RouterTestComponent],
+        [
+            { provide: Router, useValue: {} },
+            { provide: RouterExtensions, useValue: {} },
+            { provide: ActivatedRoute, useValue: {} },
+        ],
+        [NativeScriptRouterModule.forChild([])],
+        []));
+    afterEach(nsTestBedAfterEach());
+
+    it("should not provide nativescript routing services", () => {
+        return nsTestBedRender(RouterTestComponent).then((fixture) => {
+            const injector = fixture.componentRef.injector
+            assert.isNull(injector.get(LocationStrategy, null));
+            assert.isNull(injector.get(RouteReuseStrategy, null));
+        });
+    });
+
+    it("should provide nativescript routing directives", () => {
+        return nsTestBedRender(RouterTestComponent).then((fixture) => {
+            const linkDirective = fixture.componentRef.instance.nsRouterLink;
+            assert.instanceOf(linkDirective, NSRouterLink);
+        });
+    });
+});
+

--- a/tests/package.json
+++ b/tests/package.json
@@ -35,7 +35,7 @@
     "@angular/platform-browser": "~7.2.0",
     "@angular/platform-browser-dynamic": "~7.2.0",
     "@angular/router": "~7.2.0",
-    "nativescript-angular": "../nativescript-angular",
+    "nativescript-angular": "file:../nativescript-angular/nativescript-angular-7.3.0.tgz",
     "nativescript-unit-test-runner": "^0.3.4",
     "rxjs": "~6.3.3",
     "tns-core-modules": "next",


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-angular/blob/master/DevelopmentWorkflow.md#running-the-tests
- [x] Tests for the changes are included.

## What is the current behavior?
There are a couple of flaws in the `NativeScriptRouterModule`:
1. Routing services (`LocationStrategy`, `RouteReuseStrategy`, `RouterExtensions`, etc.) are provided **inside** the `NativeScriptRouterModule` module. This might cause issues with lazy loaded modules which import `NativeScriptRouterModule`.
2. The `forRoot()` and `forChild()` methods of `NativeScriptRouterModule` do not export the actual `NativeScriptRouterModule` (only the stock `RouterModule` form angular). This means that you will have to import both `NativeScriptRouterModule.forRoot/forChild(routes)` and `NativeScriptRouterModule` in every module.
## What is the new behavior?
1. Routing services are exported **only** in the module returned from `NativeScriptRouterModule.forRoot(), similar to [Angular `RouterModule`](https://github.com/angular/angular/blob/master/packages/router/src/router_module.ts#L133-L199)
2. `forRoot()` and `forChild()` now export the actual `NativeScriptRouterModule`. Now it should required to import `NativeScriptRouterModule` if you have `forChild()` or `forRoot()`

## Warning
⚠️⚠️⚠️
The `forRoot` and `fotChild` methods should contain a single return statement ([source](https://github.com/angular/angular/issues/23609#issuecomment-412361436)). Failing to comply with that leads to the following weird error when building projects with AOT:  `Function calls are not supported in decorators but 'NativeScriptRouterModule' was called.`