### PR TITLE
fix(location-strategy): crash on going back with router-outlet after closing modal

### DIFF
--- a/e2e/single-page/app/app.css
+++ b/e2e/single-page/app/app.css
@@ -1,5 +1,5 @@
 .title {
-    font-size: 30;
+    font-size: 15;
     margin: 16;
 }
 

--- a/e2e/single-page/app/app.module.ts
+++ b/e2e/single-page/app/app.module.ts
@@ -11,13 +11,18 @@ import { AppComponent } from "./app.component";
 
 import { rendererTraceCategory, viewUtilCategory, routeReuseStrategyTraceCategory, routerTraceCategory } from "nativescript-angular/trace";
 import { setCategories, enable } from "tns-core-modules/trace";
+import { ModalComponent } from "./second/modal/modal.component";
 setCategories(routerTraceCategory + "," + routeReuseStrategyTraceCategory);
 enable();
 
 @NgModule({
     declarations: [
         AppComponent,
+        ModalComponent,
         ...navigatableComponents,
+    ],
+    entryComponents:[
+        ModalComponent
     ],
     bootstrap: [AppComponent],
     providers: [

--- a/e2e/single-page/app/second/modal/modal.component.html
+++ b/e2e/single-page/app/second/modal/modal.component.html
@@ -1,0 +1,4 @@
+<StackLayout>
+    <Label text="Welcome to modal"></Label>
+    <Button text="Close Modal" (tap)="close()"></Button>
+</StackLayout>

--- a/e2e/single-page/app/second/modal/modal.component.ts
+++ b/e2e/single-page/app/second/modal/modal.component.ts
@@ -12,8 +12,8 @@ export class ModalComponent {
     constructor(private params: ModalDialogParams) {
     }
 
-    public close(result: string) {
-        this.params.closeCallback(result);
+    public close() {
+        this.params.closeCallback();
     }
 
 }

--- a/e2e/single-page/app/second/modal/modal.component.ts
+++ b/e2e/single-page/app/second/modal/modal.component.ts
@@ -1,0 +1,19 @@
+import { Component } from '@angular/core';
+import { ModalDialogParams } from "nativescript-angular/modal-dialog";
+
+@Component({
+    moduleId: module.id,
+    selector: 'modal',
+    templateUrl: './modal.component.html'
+})
+
+export class ModalComponent {
+
+    constructor(private params: ModalDialogParams) {
+    }
+
+    public close(result: string) {
+        this.params.closeCallback(result);
+    }
+
+}

--- a/e2e/single-page/app/second/second.component.ts
+++ b/e2e/single-page/app/second/second.component.ts
@@ -1,10 +1,12 @@
-import { Component, OnInit, OnDestroy } from "@angular/core";
+import { Component, OnInit, OnDestroy, ViewContainerRef } from "@angular/core";
 import { ActivatedRoute, Router, Route } from "@angular/router";
 
+import { ModalDialogService, ModalDialogOptions } from "nativescript-angular";
 import { Page } from "tns-core-modules/ui/page";
 import { Observable } from "rxjs";
 import { map } from "rxjs/operators";
 import { RouterExtensions } from "nativescript-angular/router";
+import { ModalComponent } from "./modal/modal.component";
 
 @Component({
     selector: "second",
@@ -19,12 +21,16 @@ import { RouterExtensions } from "nativescript-angular/router";
 
     <StackLayout>
         <Label [text]="'Second Component: ' + (id$ | async)" class="title"></Label>
+        <Button text="Show Modal" (tap)="onShowModal()"></Button>
         <Button text="Back" (tap)="back()"></Button>
     </StackLayout>`
 })
 export class SecondComponent implements OnInit, OnDestroy {
     public id$: Observable<number>;
-    constructor(route: ActivatedRoute, private routerExtensions: RouterExtensions) {
+    constructor(route: ActivatedRoute,
+        private routerExtensions: RouterExtensions,
+        private viewContainerRef: ViewContainerRef,
+        private modalService: ModalDialogService) {
         this.id$ = route.params.pipe(map(r => +r["id"]));
     }
 
@@ -38,5 +44,17 @@ export class SecondComponent implements OnInit, OnDestroy {
 
     back() {
         this.routerExtensions.back();
+    }
+
+    onShowModal() {
+        let options: ModalDialogOptions = {
+            viewContainerRef: this.viewContainerRef,
+            context: {
+            },
+            fullscreen: true
+        };
+
+        this.modalService.showModal(ModalComponent, options).then((dialogResult: string) => {
+        });
     }
 }

--- a/e2e/single-page/e2e/tests.e2e-spec.ts
+++ b/e2e/single-page/e2e/tests.e2e-spec.ts
@@ -19,29 +19,45 @@ describe("Single page app", () => {
     });
 
     it("should load second(1) page", async () => {
-        await findAndClick(driver, "SECOND(1)")
+        await findAndClick(driver, "SECOND(1)");
 
         await driver.findElementByAutomationText("Second Component: 1");
-        
+
         // ActionBar Title and item
         await driver.findElementByAutomationText("Second Title");
         await driver.findElementByAutomationText("ACTION2");
     });
 
     it("should load second(2) page", async () => {
-        await findAndClick(driver, "SECOND(2)")
+        await findAndClick(driver, "SECOND(2)");
 
-        await driver.findElementByAutomationText("Second Component: 1");
-        
+        await driver.findElementByAutomationText("Second Component: 2");
+
         // ActionBar Title and items
         await driver.findElementByAutomationText("Second Title");
         await driver.findElementByAutomationText("ACTION2");
         await driver.findElementByAutomationText("ADD");
     });
+
+    it("should open and close modal view", async () => {
+        await findAndClick(driver, "Show Modal");
+
+        await driver.findElementByAutomationText("Welcome to modal");
+        await findAndClick(driver, "Close Modal");
+
+        await driver.findElementByAutomationText("Second Component: 2");
+    });
+
+    it("should go back to second(1) and first", async () => {
+        await findAndClick(driver, "Back");
+        await driver.findElementByAutomationText("Second Component: 1");
+        await findAndClick(driver, "Back");
+        await driver.findElementByAutomationText("First Title");
+        await driver.findElementByAutomationText("ACTION1");
+    });
 });
 
 async function findAndClick(driver: AppiumDriver, text: string) {
-    const navigationButton =
-        await driver.findElementByAutomationText(text);
-    navigationButton.click();
+    const navigationButton = await driver.findElementByAutomationText(text);
+    await navigationButton.click();
 }

--- a/nativescript-angular/directives/dialogs.ts
+++ b/nativescript-angular/directives/dialogs.ts
@@ -87,9 +87,7 @@ export class ModalDialogService {
             frame = (parentView.page && parentView.page.frame) || topmost();
         }
 
-        if (frame) {
-            this.location._beginModalNavigation(frame);
-        }
+        this.location._beginModalNavigation(frame);
 
         return new Promise((resolve, reject) => {
             setTimeout(() => {

--- a/nativescript-angular/package.json
+++ b/nativescript-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-angular",
-  "version": "7.2.2",
+  "version": "7.2.3",
   "description": "An Angular renderer that lets you build mobile apps with NativeScript.",
   "homepage": "https://www.nativescript.org/",
   "bugs": "https://github.com/NativeScript/nativescript-angular/issues",

--- a/nativescript-angular/router/ns-location-strategy.ts
+++ b/nativescript-angular/router/ns-location-strategy.ts
@@ -564,10 +564,9 @@ export class NSLocationStrategy extends LocationStrategy {
     }
 
     findOutlet(outletKey: string, activatedRouteSnapshot?: ActivatedRouteSnapshot): Outlet {
-        const that = this;
         let outlet: Outlet = this.outlets.find((currentOutlet) => {
-            let equalModalDepth = currentOutlet.modalNavigationDepth === that._modalNavigationDepth;
-            return currentOutlet.outletKeys.indexOf(outletKey) > -1 && equalModalDepth;
+            let equalModalDepth = currentOutlet.modalNavigationDepth === this._modalNavigationDepth;
+            return equalModalDepth && currentOutlet.outletKeys.indexOf(outletKey) > -1;
         });
 
         // No Outlet with the given outletKey could happen when using nested unnamed p-r-o
@@ -575,8 +574,8 @@ export class NSLocationStrategy extends LocationStrategy {
         if (!outlet && activatedRouteSnapshot) {
             const pathByOutlets = this.getPathByOutlets(activatedRouteSnapshot);
             outlet = this.outlets.find((currentOutlet) => {
-                let equalModalDepth = currentOutlet.modalNavigationDepth === that._modalNavigationDepth;
-                return currentOutlet.pathByOutlets === pathByOutlets && equalModalDepth;
+                let equalModalDepth = currentOutlet.modalNavigationDepth === this._modalNavigationDepth;
+                return equalModalDepth && currentOutlet.pathByOutlets === pathByOutlets;
             });
         }
 

--- a/nativescript-angular/router/page-router-outlet.ts
+++ b/nativescript-angular/router/page-router-outlet.ts
@@ -422,15 +422,8 @@ export class PageRouterOutlet implements OnDestroy { // tslint:disable-line:dire
 
     private getOutlet(activatedRouteSnapshot: ActivatedRouteSnapshot): Outlet {
         const topActivatedRoute = findTopActivatedRouteNodeForOutlet(activatedRouteSnapshot);
-        const modalNavigation = this.locationStrategy._modalNavigationDepth;
         const outletKey = this.locationStrategy.getRouteFullPath(topActivatedRoute);
-        let outlet;
-
-        if (modalNavigation > 0) { // Modal with 'primary' p-r-o
-            outlet = this.locationStrategy.findOutletByModal(modalNavigation);
-        } else {
-            outlet = this.locationStrategy.findOutlet(outletKey, topActivatedRoute);
-        }
+        let outlet = this.locationStrategy.findOutlet(outletKey, topActivatedRoute);
 
         // Named lazy loaded outlet.
         if (!outlet && this.isEmptyOutlet) {


### PR DESCRIPTION
Modify location-strategy to better handle `<router-outlets>` and modal views:
 - `_beginModalNavigation` method shouldn't set `currentOutlet` to null when no outlet for the given Frame found.

 - `clearOutlet` method: Do not remove outlet, from outlets collection, who belongs to `<router-outlet>` since it doesn't have any frames[]
 - `findOutlet` method should always respect the current `_modalNavigationDepth` when searching for outlet, since there could be 2 or more identical outlets on different modal views ( _primary-> (modal:primary)->(modal2->primary)_) 

- make `findOutletByModal ` private, since it won't be used outside location-strategy anymore 

Fix https://github.com/NativeScript/nativescript-angular/issues/1735