### PR TITLE
chore(tsconfig): remove path resolution for short imports (`ui/page`)

### DIFF
--- a/nativescript-angular/tsconfig.json
+++ b/nativescript-angular/tsconfig.json
@@ -16,14 +16,7 @@
         "dom",
         "es6",
         "es2015.iterable"
-    ],
-    "baseUrl": ".",
-    "paths": {
-        "*": [
-            "./node_modules/tns-core-modules/*",
-            "./node_modules/*"
-        ]
-    }
+    ]
   },
   "angularCompilerOptions": {
     "genDir": ".",


### PR DESCRIPTION
The usage of short imports, e.g, `import * as Page from "ui/page"`
instead of `import * as Page from "tns-core-modules/ui/page"` is
*deprecated* since {N} 5.2.