### PR TITLE
Refactor modal options to expose current/future core options

### DIFF
--- a/nativescript-angular/directives/dialogs.ts
+++ b/nativescript-angular/directives/dialogs.ts
@@ -19,9 +19,10 @@ import { PageFactory, PAGE_FACTORY } from "../platform-providers";
 import { once } from "../common/utils";
 import { topmost, Frame, ShowModalOptions } from "tns-core-modules/ui/frame";
 
-export type BaseShowModalOptions = Pick<ShowModalOptions, Exclude<keyof ShowModalOptions, "closeCallback">>;
+export type BaseShowModalOptions = Pick<ShowModalOptions, Exclude<keyof ShowModalOptions, "closeCallback" | "context">>;
 
 export interface ModalDialogOptions extends BaseShowModalOptions {
+    context?: any;
     viewContainerRef?: ViewContainerRef;
     moduleRef?: NgModuleRef<any>;
 }
@@ -34,6 +35,7 @@ export class ModalDialogParams {
 }
 
 interface ShowDialogOptions extends BaseShowModalOptions {
+    context: any;
     containerRef: ViewContainerRef;
     doneCallback;
     pageFactory: PageFactory;


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-angular/blob/master/DevelopmentWorkflow.md#running-the-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
The current exposed options for showModal differs from the options available in the core.

## What is the new behavior?
All current and future non-angular options are exposed by leveraging Typescript's `Pick` type.

https://github.com/NativeScript/nativescript-angular/pull/1767 attempts to fix this, but another property has been exposed (`android: any`), so other PRs would be needed for every new property.

I'm asking for this PR to be considered over #1767 

Fixes #1709.
