### PR TITLE
Update modal to allow use of ios presentationStyle

### DIFF
--- a/e2e/modal-navigation-ng/app/navigation/basic.navigation.component.ts
+++ b/e2e/modal-navigation-ng/app/navigation/basic.navigation.component.ts
@@ -1,4 +1,4 @@
-import { Component, ViewContainerRef, Input, ViewChild } from "@angular/core";
+import { Component, ViewContainerRef, Input, ViewChild, ElementRef } from "@angular/core";
 import { Router, NavigationEnd } from "@angular/router";
 import { ModalDialogService, ModalDialogOptions } from "nativescript-angular/directives/dialogs";
 import { ModalComponent } from "../modal/modal.component";
@@ -16,14 +16,14 @@ import { ModalViewComponent } from "~/modal-shared/modal-view.component";
     <Button text="Show Modal Without Frame" (tap)="onModalNoFrame()" textAlignment="left"></Button>
     <Button text="Show Modal Page With Frame" (tap)="onModalFrame()" textAlignment="left"></Button>
     <Button text="Show Shared Modal" (tap)="onRootModalTap()" textAlignment="left"></Button>
-    <Button #popoverButtonComp text="Show Dialog" (tap)="onShowDialog()" textAlignment="left"></Button>
-    <Button text="Show 'popover' modal" (tap)="onPopoverModal()" textAlignment="left"></Button>
+    <Button text="Show Dialog" (tap)="onShowDialog()" textAlignment="left"></Button>
+    <Button #popoverButtonComp text="Show 'popover' modal" (tap)="onPopoverModal()" textAlignment="left"></Button>
 </StackLayout>`
 })
 
 export class BasicsNavigationComponent {
 
-    @ViewChild("popoverButtonComp") popoverButtonComp;
+    @ViewChild("popoverButtonComp") popoverButtonComp: ElementRef;
     @Input() col: number;
     constructor(
         private modal: ModalDialogService,
@@ -94,7 +94,7 @@ export class BasicsNavigationComponent {
             ios: {
                 presentationStyle: UIModalPresentationStyle.Popover
             },
-            sourceView: this.popoverButtonComp
+            target: this.popoverButtonComp.nativeElement
         };
 
         this.modal.showModal(ModalViewComponent, options)

--- a/e2e/modal-navigation-ng/app/navigation/basic.navigation.component.ts
+++ b/e2e/modal-navigation-ng/app/navigation/basic.navigation.component.ts
@@ -1,4 +1,4 @@
-import { Component, ViewContainerRef, Input } from "@angular/core";
+import { Component, ViewContainerRef, Input, ViewChild } from "@angular/core";
 import { Router, NavigationEnd } from "@angular/router";
 import { ModalDialogService, ModalDialogOptions } from "nativescript-angular/directives/dialogs";
 import { ModalComponent } from "../modal/modal.component";
@@ -16,12 +16,14 @@ import { ModalViewComponent } from "~/modal-shared/modal-view.component";
     <Button text="Show Modal Without Frame" (tap)="onModalNoFrame()" textAlignment="left"></Button>
     <Button text="Show Modal Page With Frame" (tap)="onModalFrame()" textAlignment="left"></Button>
     <Button text="Show Shared Modal" (tap)="onRootModalTap()" textAlignment="left"></Button>
-    <Button text="Show Dialog" (tap)="onShowDialog()" textAlignment="left"></Button>
+    <Button #popoverButtonComp text="Show Dialog" (tap)="onShowDialog()" textAlignment="left"></Button>
+    <Button text="Show 'popover' modal" (tap)="onPopoverModal()" textAlignment="left"></Button>
 </StackLayout>`
 })
 
 export class BasicsNavigationComponent {
 
+    @ViewChild("popoverButtonComp") popoverButtonComp;
     @Input() col: number;
     constructor(
         private modal: ModalDialogService,
@@ -29,7 +31,7 @@ export class BasicsNavigationComponent {
         private vcf: ViewContainerRef,
         private viewContainerRefService: ViewContainerRefService) {
     }
- 
+
     onModalNoFrame() {
         const options: ModalDialogOptions = {
             context: {
@@ -74,14 +76,28 @@ export class BasicsNavigationComponent {
 
     onRootModalTap(): void {
         const options: ModalDialogOptions = {
-          viewContainerRef: this.viewContainerRefService.root,
-          context: {},
-          fullscreen: true
+            viewContainerRef: this.viewContainerRefService.root,
+            context: {},
+            fullscreen: true
         };
-     
+
         this.modal.showModal(ModalViewComponent, options)
-        .then((result: string) => {
-          console.log(result);
-        });
-      }
+            .then((result: string) => {
+                console.log(result);
+            });
+    }
+
+    onPopoverModal() {
+        const options: ModalDialogOptions = {
+            viewContainerRef: this.viewContainerRefService.root,
+            context: {},
+            ios: {
+                presentationStyle: UIModalPresentationStyle.Popover
+            },
+            sourceView: this.popoverButtonComp
+        };
+
+        this.modal.showModal(ModalViewComponent, options)
+            .then((result: string) => { console.log(result);});
+    }
 }

--- a/e2e/modal-navigation-ng/package.json
+++ b/e2e/modal-navigation-ng/package.json
@@ -46,6 +46,7 @@
     "nativescript-dev-appium": "next",
     "nativescript-dev-typescript": "next",
     "nativescript-dev-webpack": "next",
+    "tns-platform-declarations": "next",
     "typescript": "~3.1.1"
   },
   "scripts": {

--- a/e2e/modal-navigation-ng/references.d.ts
+++ b/e2e/modal-navigation-ng/references.d.ts
@@ -1,0 +1,1 @@
+/// <reference path="./node_modules/tns-platform-declarations/ios.d.ts" />

--- a/nativescript-angular/directives/dialogs.ts
+++ b/nativescript-angular/directives/dialogs.ts
@@ -18,7 +18,8 @@ import { AppHostView } from "../app-host-view";
 import { DetachedLoader } from "../common/detached-loader";
 import { PageFactory, PAGE_FACTORY } from "../platform-providers";
 import { once } from "../common/utils";
-import { topmost, Frame, ShowModalOptions } from "tns-core-modules/ui/frame";
+import { topmost, Frame } from "tns-core-modules/ui/frame";
+import { ShowModalOptions } from  "tns-core-modules/ui/core/view";
 
 export type BaseShowModalOptions = Pick<ShowModalOptions, Exclude<keyof ShowModalOptions, "closeCallback" | "context">>;
 
@@ -26,7 +27,7 @@ export interface ModalDialogOptions extends BaseShowModalOptions {
     context?: any;
     viewContainerRef?: ViewContainerRef;
     moduleRef?: NgModuleRef<any>;
-    sourceView?: ElementRef;
+    target?: View;
 }
 
 export class ModalDialogParams {
@@ -62,9 +63,10 @@ export class ModalDialogService {
         }
 
         let parentView = options.viewContainerRef.element.nativeElement;
-        if (options.sourceView) {
-            parentView = options.sourceView.nativeElement;
+        if (options.target) {
+            parentView = options.target;
         }
+
         if (parentView instanceof AppHostView && parentView.ngAppRoot) {
             parentView = parentView.ngAppRoot;
         }

--- a/nativescript-angular/directives/dialogs.ts
+++ b/nativescript-angular/directives/dialogs.ts
@@ -145,9 +145,6 @@ export class ModalDialogService {
                 (<any>componentView.parent).removeChild(componentView);
             }
 
-
-            // TODO: remove <any> cast after https://github.com/NativeScript/NativeScript/pull/5734
-            // is in a published version of tns-core-modules.
             options.parentView.showModal(componentView, { ...options, closeCallback });
         });
     }

--- a/nativescript-angular/directives/dialogs.ts
+++ b/nativescript-angular/directives/dialogs.ts
@@ -7,6 +7,7 @@ import {
     ReflectiveInjector,
     Type,
     ViewContainerRef,
+    ElementRef,
 } from "@angular/core";
 
 import { NSLocationStrategy } from "../router/ns-location-strategy";
@@ -17,15 +18,15 @@ import { AppHostView } from "../app-host-view";
 import { DetachedLoader } from "../common/detached-loader";
 import { PageFactory, PAGE_FACTORY } from "../platform-providers";
 import { once } from "../common/utils";
-import { topmost, Frame } from "tns-core-modules/ui/frame";
+import { topmost, Frame, ShowModalOptions } from "tns-core-modules/ui/frame";
 
-export interface ModalDialogOptions {
+export type BaseShowModalOptions = Pick<ShowModalOptions, Exclude<keyof ShowModalOptions, "closeCallback" | "context">>;
+
+export interface ModalDialogOptions extends BaseShowModalOptions {
     context?: any;
-    fullscreen?: boolean;
-    animated?: boolean;
-    stretched?: boolean;
     viewContainerRef?: ViewContainerRef;
     moduleRef?: NgModuleRef<any>;
+    sourceView?: ElementRef;
 }
 
 export class ModalDialogParams {
@@ -35,13 +36,10 @@ export class ModalDialogParams {
     }
 }
 
-interface ShowDialogOptions {
+interface ShowDialogOptions extends BaseShowModalOptions {
     containerRef: ViewContainerRef;
     context: any;
     doneCallback;
-    fullscreen: boolean;
-    animated: boolean;
-    stretched: boolean;
     pageFactory: PageFactory;
     parentView: ViewBase;
     resolver: ComponentFactoryResolver;
@@ -54,16 +52,19 @@ export class ModalDialogService {
     }
 
     public showModal(type: Type<any>,
-        { viewContainerRef, moduleRef, context, fullscreen, animated, stretched }: ModalDialogOptions
+        options: ModalDialogOptions
     ): Promise<any> {
-        if (!viewContainerRef) {
+        if (!options.viewContainerRef) {
             throw new Error(
                 "No viewContainerRef: " +
                 "Make sure you pass viewContainerRef in ModalDialogOptions."
             );
         }
 
-        let parentView = viewContainerRef.element.nativeElement;
+        let parentView = options.viewContainerRef.element.nativeElement;
+        if (options.sourceView) {
+            parentView = options.sourceView.nativeElement;
+        }
         if (parentView instanceof AppHostView && parentView.ngAppRoot) {
             parentView = parentView.ngAppRoot;
         }
@@ -75,11 +76,11 @@ export class ModalDialogService {
             parentView = parentView._ngDialogRoot;
         }
 
-        const pageFactory: PageFactory = viewContainerRef.injector.get(PAGE_FACTORY);
+        const pageFactory: PageFactory = options.viewContainerRef.injector.get(PAGE_FACTORY);
 
         // resolve from particular module (moduleRef)
         // or from same module as parentView (viewContainerRef)
-        const componentContainer = moduleRef || viewContainerRef;
+        const componentContainer = options.moduleRef || options.viewContainerRef;
         const resolver = componentContainer.injector.get(ComponentFactoryResolver);
 
         let frame = parentView;
@@ -93,16 +94,14 @@ export class ModalDialogService {
             setTimeout(() => {
                 try {
                     this._showDialog({
-                        containerRef: viewContainerRef,
-                        context,
+                        ...options,
+                        containerRef: options.viewContainerRef,
+                        context: options.context,
                         doneCallback: resolve,
-                        fullscreen,
-                        animated,
-                        stretched,
                         pageFactory,
                         parentView,
                         resolver,
-                        type,
+                        type
                     });
                 } catch (err) {
                     reject(err);
@@ -111,23 +110,12 @@ export class ModalDialogService {
         });
     }
 
-    private _showDialog({
-        containerRef,
-        context,
-        doneCallback,
-        fullscreen,
-        animated,
-        stretched,
-        pageFactory,
-        parentView,
-        resolver,
-        type,
-    }: ShowDialogOptions): void {
+    private _showDialog(options: ShowDialogOptions): void {
         let componentView: View;
         let detachedLoaderRef: ComponentRef<DetachedLoader>;
 
         const closeCallback = once((...args) => {
-            doneCallback.apply(undefined, args);
+            options.doneCallback.apply(undefined, args);
             if (componentView) {
                 componentView.closeModal();
                 this.location._closeModalNavigation();
@@ -136,15 +124,15 @@ export class ModalDialogService {
             }
         });
 
-        const modalParams = new ModalDialogParams(context, closeCallback);
+        const modalParams = new ModalDialogParams(options.context, closeCallback);
         const providers = ReflectiveInjector.resolve([
             { provide: ModalDialogParams, useValue: modalParams },
         ]);
 
-        const childInjector = ReflectiveInjector.fromResolvedProviders(providers, containerRef.parentInjector);
-        const detachedFactory = resolver.resolveComponentFactory(DetachedLoader);
-        detachedLoaderRef = containerRef.createComponent(detachedFactory, -1, childInjector, null);
-        detachedLoaderRef.instance.loadComponent(type).then((compRef) => {
+        const childInjector = ReflectiveInjector.fromResolvedProviders(providers, options.containerRef.parentInjector);
+        const detachedFactory = options.resolver.resolveComponentFactory(DetachedLoader);
+        detachedLoaderRef = options.containerRef.createComponent(detachedFactory, -1, childInjector, null);
+        detachedLoaderRef.instance.loadComponent(options.type).then((compRef) => {
             const detachedProxy = <ProxyViewContainer>compRef.location.nativeElement;
 
             if (detachedProxy.getChildrenCount() > 1) {
@@ -157,9 +145,10 @@ export class ModalDialogService {
                 (<any>componentView.parent).removeChild(componentView);
             }
 
+
             // TODO: remove <any> cast after https://github.com/NativeScript/NativeScript/pull/5734
             // is in a published version of tns-core-modules.
-            (<any>parentView).showModal(componentView, context, closeCallback, fullscreen, animated, stretched);
+            (<any>options.parentView).showModal(componentView, { ...options, closeCallback });
         });
     }
 }

--- a/nativescript-angular/directives/dialogs.ts
+++ b/nativescript-angular/directives/dialogs.ts
@@ -148,7 +148,7 @@ export class ModalDialogService {
 
             // TODO: remove <any> cast after https://github.com/NativeScript/NativeScript/pull/5734
             // is in a published version of tns-core-modules.
-            (<any>options.parentView).showModal(componentView, { ...options, closeCallback });
+            options.parentView.showModal(componentView, { ...options, closeCallback });
         });
     }
 }

--- a/nativescript-angular/directives/dialogs.ts
+++ b/nativescript-angular/directives/dialogs.ts
@@ -6,8 +6,7 @@ import {
     NgModuleRef,
     ReflectiveInjector,
     Type,
-    ViewContainerRef,
-    ElementRef,
+    ViewContainerRef
 } from "@angular/core";
 
 import { NSLocationStrategy } from "../router/ns-location-strategy";


### PR DESCRIPTION
Refactored [this](https://github.com/NativeScript/nativescript-angular/pull/1767) and [this](https://github.com/NativeScript/nativescript-angular/pull/1769) PRs into a merged PR and also added "test case" to the _modal-navigation-ng_ application for future e2e test.
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [X] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [X] You have signed the [CLA](http://www.nativescript.org/cla).
- [X] All existing tests are passing: https://github.com/NativeScript/nativescript-angular/blob/master/DevelopmentWorkflow.md#running-the-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
### From PR [1767](https://github.com/NativeScript/nativescript-angular/pull/1767)
As per this issue https://github.com/NativeScript/nativescript-angular/issues/1709 it's currently not possible to use an ios popover style modal.

### From PR [1769](https://github.com/NativeScript/nativescript-angular/pull/1769)
The current exposed options for showModal differs from the options available in the core.

## What is the new behavior?
### From PR [1767](https://github.com/NativeScript/nativescript-angular/pull/1767)
I've added a couple of new options to `ModalDialogOptions`

- sourceView - this is required as normally you would use `viewContainerRef` but if you want to attach a popover to a button for example you need to pass in the button element.
- ios - allows you to use `presentationStyle: UIModalPresentationStyle.Popover`, the only caveat with this is you will need to install `tns-platform-declarations` to be able to use it.

You will also see I've added a `closeModal()` option. There were 2 reasons for this. Firstly if you click on the background the popover disappears but when you try to open another popover you get an error warning a modal already exists.  So at the moment if a `sourceView` is present it will close any pre existing modal first before opening a new one.

The second issue I had is if I opened a popover then navigated back then went back to the same page to popover would reappear but not attached to the view it was previously attached to and with no content. So I made `closeModal()` public and call it when going back. i.e

```
    this.location.onPopState((resp: any) => {
      if (resp.pop) {
        this._modalService.closeModal();
      }
    });
```
I'm sure there's maybe a better way to resolve these issues but wasn't sure on that.

This solutions probably isn't perfect but it does work without any issues as far as I can tell, so think it's a good starting point at least.

### From PR [1769](https://github.com/NativeScript/nativescript-angular/pull/1769)
All current and future non-angular options are exposed by leveraging Typescript's `Pick` type.

## Fixes/Implements/Closes
### From PR [1767](https://github.com/NativeScript/nativescript-angular/pull/1767)
https://github.com/NativeScript/nativescript-angular/issues/1709
