### PR TITLE
Resolve multiple issues with modal views that use `presentationStyle: UIModalPresentationStyle.Popover`

### DIFF
--- a/nativescript-angular/directives/dialogs.ts
+++ b/nativescript-angular/directives/dialogs.ts
@@ -117,9 +117,7 @@ export class ModalDialogService {
         const closeCallback = once((...args) => {
             options.doneCallback.apply(undefined, args);
             if (componentView) {
-                if (componentView.viewController) {
-                    componentView.closeModal();
-                }
+                componentView.closeModal();
                 this.location._closeModalNavigation();
                 detachedLoaderRef.instance.detectChanges();
                 detachedLoaderRef.destroy();
@@ -146,8 +144,6 @@ export class ModalDialogService {
                 (<any>componentView.parent)._ngDialogRoot = componentView;
                 (<any>componentView.parent).removeChild(componentView);
             }
-
-            componentView.on(View.popoverClosedEvent, closeCallback);
 
             options.parentView.showModal(componentView, { ...options, closeCallback });
         });

--- a/nativescript-angular/directives/dialogs.ts
+++ b/nativescript-angular/directives/dialogs.ts
@@ -10,7 +10,7 @@ import {
 } from "@angular/core";
 
 import { NSLocationStrategy } from "../router/ns-location-strategy";
-import { View, ViewBase } from "tns-core-modules/ui/core/view";
+import { View, ViewBase, ShowModalOptions } from "tns-core-modules/ui/core/view";
 import { ProxyViewContainer } from "tns-core-modules/ui/proxy-view-container/proxy-view-container";
 
 import { AppHostView } from "../app-host-view";
@@ -18,7 +18,6 @@ import { DetachedLoader } from "../common/detached-loader";
 import { PageFactory, PAGE_FACTORY } from "../platform-providers";
 import { once } from "../common/utils";
 import { topmost, Frame } from "tns-core-modules/ui/frame";
-import { ShowModalOptions } from  "tns-core-modules/ui/core/view";
 
 export type BaseShowModalOptions = Pick<ShowModalOptions, Exclude<keyof ShowModalOptions, "closeCallback" | "context">>;
 
@@ -118,7 +117,9 @@ export class ModalDialogService {
         const closeCallback = once((...args) => {
             options.doneCallback.apply(undefined, args);
             if (componentView) {
-                componentView.closeModal();
+                if (componentView.viewController) {
+                    componentView.closeModal();
+                }
                 this.location._closeModalNavigation();
                 detachedLoaderRef.instance.detectChanges();
                 detachedLoaderRef.destroy();
@@ -145,6 +146,8 @@ export class ModalDialogService {
                 (<any>componentView.parent)._ngDialogRoot = componentView;
                 (<any>componentView.parent).removeChild(componentView);
             }
+
+            componentView.on(View.popoverClosedEvent, closeCallback);
 
             options.parentView.showModal(componentView, { ...options, closeCallback });
         });


### PR DESCRIPTION
This PR requires a PR in the tns-core-modules to be merged first: https://github.com/NativeScript/NativeScript/issues/7050

## PR Checklist

- [X] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [X] You have signed the [CLA](http://www.nativescript.org/cla).
- [X] All existing tests are passing: https://github.com/NativeScript/nativescript-angular/blob/master/DevelopmentWorkflow.md#running-the-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
If you open a modal that has options for `presentationStyle` set to `UIModalPresentationStyle.Popover` if you tap outside of the popup it will be closed but opening a next modal will open empty broken modal.

## What is the new behavior?
If you open a modal that has options for `presentationStyle` set to `UIModalPresentationStyle.Popover` if you tap outside of the popup it will be closed correctly and opening next modal will work as expected.

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->