### PR TITLE
chore: bump version to 7.3.0

### DIFF
--- a/nativescript-angular/package.json
+++ b/nativescript-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-angular",
-  "version": "7.2.4",
+  "version": "7.3.0",
   "description": "An Angular renderer that lets you build mobile apps with NativeScript.",
   "homepage": "https://www.nativescript.org/",
   "bugs": "https://github.com/NativeScript/nativescript-angular/issues",


### PR DESCRIPTION
We need to bump this version so otherwise the version could be mismatch.