### PR TITLE
fix: revert recursive remove -causing crashes

### DIFF
--- a/nativescript-angular/router/page-router-outlet.ts
+++ b/nativescript-angular/router/page-router-outlet.ts
@@ -358,7 +358,7 @@ export class PageRouterOutlet implements OnDestroy { // tslint:disable-line:dire
         // Component loaded. Find its root native view.
         const componentView = componentRef.location.nativeElement;
         // Remove it from original native parent.
-        this.viewUtil.removeChild(componentView.parent, componentView, false);
+        this.viewUtil.removeChild(componentView.parent, componentView);
         // Add it to the new page
         this.viewUtil.insertChild(page, componentView);
 

--- a/nativescript-angular/view-util.ts
+++ b/nativescript-angular/view-util.ts
@@ -157,10 +157,9 @@ export class ViewUtil {
         return next;
     }
 
-    public removeChild(parent: View, child: View, removeGrandchildren = true) {
+    public removeChild(parent: View, child: View) {
         if (isLogEnabled()) {
-           traceLog(`ViewUtil.removeChild parent: ${parent} child: ${child} `
-            + `remove grandchildren: ${removeGrandchildren}`);
+           traceLog(`ViewUtil.removeChild parent: ${parent} child: ${child}`);
         }
 
         if (!parent) {
@@ -169,17 +168,6 @@ export class ViewUtil {
 
         const extendedParent = this.ensureNgViewExtensions(parent);
         const extendedChild = this.ensureNgViewExtensions(child);
-
-        // Remove the child's children and their children
-        // Unless called from PageRouterOutlet when the child is moved from once parent to another.
-        while (extendedChild && extendedChild.firstChild && removeGrandchildren) {
-            const grandchild = extendedChild.firstChild;
-            if (isLogEnabled()) {
-                traceLog(`ViewUtil.removeChild parent: ${parent} child: ${extendedChild} grandchild: ${grandchild}`);
-            }
-
-            this.removeChild(extendedChild, grandchild);
-        }
 
         this.removeFromQueue(extendedParent, extendedChild);
         if (!isDetachedElement(extendedChild)) {


### PR DESCRIPTION
This reverting the recursive removeChild implemented in #1740 by @m-abs 
We found the following issues and decided to revert the change until they are resolved:
1. #1818 - Error: `Cannot read property 'textTransform' of undefined` in `createSpannableStringBuilder`
2. Crash in [nativescript-sdk-examples-ng](https://github.com/NativeScript/nativescript-sdk-examples-ng) with tab view. To reproduce go to : `TabView` -> `Basic` -> `[back]`. You get a crash (in console) and cannot navigate any more