### PR TITLE
fix(1845): CSS special selector ":host" only work first time

### DIFF
--- a/nativescript-angular/renderer.ts
+++ b/nativescript-angular/renderer.ts
@@ -57,8 +57,12 @@ export class NativeScriptRendererFactory implements RendererFactory2 {
             return this.defaultRenderer;
         }
 
-        let renderer: NativeScriptRenderer = this.componentRenderers.get(type.id);
+        let renderer = this.componentRenderers.get(type.id);
         if (renderer) {
+            if (renderer instanceof EmulatedRenderer) {
+                renderer.applyToHost(element);
+            }
+
             return renderer;
         }
 

--- a/tests/app/tests/renderer-tests.ts
+++ b/tests/app/tests/renderer-tests.ts
@@ -16,6 +16,7 @@ import { View, fontInternalProperty, backgroundInternalProperty } from "tns-core
 import { nsTestBedAfterEach, nsTestBedBeforeEach, nsTestBedRender } from "nativescript-angular/testing";
 import { ComponentFixture, TestBed, async } from "@angular/core/testing";
 import { Observable, ReplaySubject } from "rxjs";
+import { Label } from "tns-core-modules/ui/label/label";
 
 @Component({
     template: `<StackLayout><Label text="Layout"></Label></StackLayout>`
@@ -94,6 +95,37 @@ export class StyledLabelCmp {
 })
 export class StyledLabelCmp2 {
     constructor(public elementRef: ElementRef) {
+    }
+}
+
+@Component({
+    selector: "host-styled",
+    styles: [`
+        Label {
+            color: blue;
+        }
+
+        :host Label {
+            color: red;
+        }
+    `
+    ],
+    template: `<Label text="Styled!"></Label>`
+})
+export class HostStyledCmp {
+    constructor(public elementRef: ElementRef<ProxyViewContainer>) {
+    }
+}
+
+@Component({
+    selector: "host-styled-parent",
+    template: `
+        <host-styled></host-styled>
+        <host-styled></host-styled>
+    `
+})
+export class HostStyledParentCmp {
+    constructor(public elementRef: ElementRef<ProxyViewContainer>) {
     }
 }
 
@@ -251,6 +283,7 @@ describe("Renderer E2E", () => {
         LayoutWithLabel, LabelCmp, LabelContainer,
         ProjectableCmp, ProjectionContainer,
         StyledLabelCmp, StyledLabelCmp2,
+        HostStyledCmp, HostStyledParentCmp,
         NgIfLabel, NgIfThenElseComponent, NgIfMultiple,
         NgIfTwoElements, NgIfMultiple,
         NgIfElseComponent, NgIfThenElseComponent,
@@ -290,6 +323,18 @@ describe("Renderer E2E", () => {
             const componentRoot = componentRef.instance.elementRef.nativeElement;
             const label = (<ProxyViewContainer>componentRoot).getChildAt(0);
             assert.equal(Red, label.style.color.hex);
+        });
+    });
+
+    it("applies component :host styles", () => {
+        return nsTestBedRender(HostStyledParentCmp).then((fixture) => {
+            const proxyView = fixture.componentRef.instance.elementRef.nativeElement;
+
+            for (let i = 0; i < 2; i += 1) {
+                const child = proxyView.getChildAt(i) as ProxyViewContainer;
+                const label = child.getChildAt(0) as Label;
+                assert.equal(Red, label.style.color.hex);
+            }
         });
     });
 


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-angular/blob/master/DevelopmentWorkflow.md#running-the-tests
- [x] Tests for the changes are included.

I can't run the unit tests, so I couldn't write a test for this fix.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
`:host` selector only works for on first instance of a component.

This is caused by `_nghost-%COMP%`-property only being applied when the `EmulatedRenderer` is created for a type, but not when it is reuse.

## What is the new behavior?
<!-- Describe the changes. -->
The `_nghost-%COMP%`-property is applied when the `EmulatedRenderer` is reused.

Fixes #1845 

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

