### PR TITLE
[DO NOT MERGE] Make repo apps compatible with `--bundle`

### DIFF
--- a/e2e/modal-navigation-ng/package.json
+++ b/e2e/modal-navigation-ng/package.json
@@ -23,6 +23,7 @@
     "@angular/platform-browser-dynamic": "8.0.0",
     "@angular/router": "8.0.0",
     "nativescript-angular": "file:../../nativescript-angular",
+    "nativescript-dev-webpack": "webpack",
     "nativescript-theme-core": "~1.0.4",
     "reflect-metadata": "~0.1.8",
     "rxjs": "~6.3.3",

--- a/e2e/modal-navigation-ng/tsconfig.json
+++ b/e2e/modal-navigation-ng/tsconfig.json
@@ -22,8 +22,16 @@
             ]
         }
     },
+    "include": [
+        "../../nativescript-angular",
+        "**/*"
+    ],
     "exclude": [
+        "../../nativescript-angular/node_modules",
+        "../../nativescript-angular/**/*.d.ts",
         "node_modules",
-        "platforms"
+        "platforms",
+        "**/*.aot",
+        "e2e"
     ]
 }

--- a/e2e/nested-router-tab-view/app/app.routing.ts
+++ b/e2e/nested-router-tab-view/app/app.routing.ts
@@ -10,6 +10,7 @@ import { LoginComponent } from "./login/login.component";
 import { TabsComponent } from "./tabs/tabs.component";
 import { HomeComponent } from "./home/home.component";
 import { HomeLazyModule } from "./home-lazy/home-lazy.module";
+import { CustomTabsModule } from "./custom-tabs/custom-tabs.module"
 import { AboutComponent } from "./about/about.component";
 import { AboutNestedComponent } from "./about/about-nested.component";
 
@@ -51,7 +52,7 @@ const routes: Routes = [
     },
     {
         path: "custom-tabs",
-        loadChildren: "./custom-tabs/custom-tabs.module#CustomTabsModule",
+        loadChildren: () => CustomTabsModule,
     },
     {
         path: "tabs", component: TabsComponent, children: [

--- a/e2e/nested-router-tab-view/app/app.routing.ts
+++ b/e2e/nested-router-tab-view/app/app.routing.ts
@@ -9,6 +9,7 @@ import { TeamDetailComponent } from "./team/team-detail.component";
 import { LoginComponent } from "./login/login.component";
 import { TabsComponent } from "./tabs/tabs.component";
 import { HomeComponent } from "./home/home.component";
+import { HomeLazyModule } from "./home-lazy/home-lazy.module";
 import { AboutComponent } from "./about/about.component";
 import { AboutNestedComponent } from "./about/about-nested.component";
 
@@ -46,7 +47,7 @@ const routes: Routes = [
     },
     {
         path: "home-lazy",
-        loadChildren: "./home-lazy/home-lazy.module#HomeLazyModule",
+        loadChildren: () => HomeLazyModule,
     },
     {
         path: "custom-tabs",

--- a/e2e/nested-router-tab-view/package.json
+++ b/e2e/nested-router-tab-view/package.json
@@ -6,7 +6,7 @@
   "nativescript": {
     "id": "org.nativescript.nestedroutertabview",
     "tns-ios": {
-      "version": "6.0.0-2019-06-10-154118-03"
+      "version": "next"
     },
     "tns-android": {
       "version": "next"

--- a/e2e/nested-router-tab-view/package.json
+++ b/e2e/nested-router-tab-view/package.json
@@ -6,7 +6,7 @@
   "nativescript": {
     "id": "org.nativescript.nestedroutertabview",
     "tns-ios": {
-      "version": "next"
+      "version": "6.0.0-2019-06-10-154118-03"
     },
     "tns-android": {
       "version": "next"
@@ -23,6 +23,7 @@
     "@angular/platform-browser-dynamic": "8.0.0",
     "@angular/router": "8.0.0",
     "nativescript-angular": "file:../../nativescript-angular",
+    "nativescript-dev-webpack": "webpack",
     "nativescript-theme-core": "~1.0.4",
     "reflect-metadata": "~0.1.8",
     "rxjs": "~6.3.3",

--- a/e2e/nested-router-tab-view/tsconfig.json
+++ b/e2e/nested-router-tab-view/tsconfig.json
@@ -6,7 +6,6 @@
         "emitDecoratorMetadata": true,
         "noEmitHelpers": true,
         "noEmitOnError": true,
-        "sourceMap": true,
         "lib": [
             "es6",
             "dom",
@@ -23,8 +22,16 @@
             ]
         }
     },
+    "include": [
+        "../../nativescript-angular",
+        "**/*"
+    ],
     "exclude": [
+        "../../nativescript-angular/node_modules",
+        "../../nativescript-angular/**/*.d.ts",
         "node_modules",
-        "platforms"
+        "platforms",
+        "**/*.aot",
+        "e2e"
     ]
 }

--- a/e2e/router-tab-view/package.json
+++ b/e2e/router-tab-view/package.json
@@ -23,6 +23,7 @@
     "@angular/platform-browser-dynamic": "8.0.0",
     "@angular/router": "8.0.0",
     "nativescript-angular": "file:../../nativescript-angular",
+    "nativescript-dev-webpack": "webpack",
     "nativescript-theme-core": "~1.0.4",
     "reflect-metadata": "~0.1.8",
     "rxjs": "~6.3.3",
@@ -41,7 +42,9 @@
     "mochawesome": "~3.1.2",
     "nativescript-dev-appium": "next",
     "nativescript-dev-typescript": "next",
-    "typescript": "~3.4.5"
+    "typescript": "~3.4.5",
+    "@angular/compiler-cli": "8.0.0",
+    "@ngtools/webpack": "8.0.0"
   },
   "scripts": {
     "e2e": "tsc -p e2e && mocha --opts ../config/mocha.opts --recursive e2e --appiumCapsLocation ../config/appium.capabilities.json",

--- a/e2e/router-tab-view/tsconfig.json
+++ b/e2e/router-tab-view/tsconfig.json
@@ -16,11 +16,22 @@
             "*": [
                 "./node_modules/tns-core-modules/*",
                 "./node_modules/*"
+            ],
+            "~/*": [
+                "app/*"
             ]
         }
     },
+    "include": [
+        "../../nativescript-angular",
+        "**/*"
+    ],
     "exclude": [
+        "../../nativescript-angular/node_modules",
+        "../../nativescript-angular/**/*.d.ts",
         "node_modules",
-        "platforms"
+        "platforms",
+        "**/*.aot",
+        "e2e"
     ]
 }

--- a/tests/app/snippets/gestures.component.ts
+++ b/tests/app/snippets/gestures.component.ts
@@ -9,7 +9,8 @@ import {
 
 @Component({
     selector: "gestures",
-    templateUrl: "snippets/gestures.component.html",
+    moduleId: module.id,
+    templateUrl: "gestures.component.html",
     styles: ["label { font-size: 32; margin: 2; background-color: lightgreen;}"]
 })
 export class GestureComponent {

--- a/tests/app/snippets/icon-font.component.ts
+++ b/tests/app/snippets/icon-font.component.ts
@@ -4,8 +4,9 @@ import {Component} from "@angular/core";
 @Component({
     // >> (hide)
     selector: "icon-font",
-    templateUrl: "snippets/icon-font.component.html",
-    styleUrls: ["snippets/icon-font.component.css"]
+    moduleId: module.id,
+    templateUrl: "icon-font.component.html",
+    styleUrls: ["icon-font.component.css"]
     // << (hide)
     // ...
 })

--- a/tests/app/snippets/layouts.component.ts
+++ b/tests/app/snippets/layouts.component.ts
@@ -2,7 +2,8 @@ import {Component} from "@angular/core";
 
 @Component({
     selector: "gestures",
-    templateUrl: "snippets/layouts.component.html",
+    moduleId: module.id,
+    templateUrl: "layouts.component.html",
     styles: [
         "Image { background-color: coral }",
         ".title { margin: 10; horizontal-align: center; font-size: 32 }",

--- a/tests/app/snippets/navigation/router-extensions.ts
+++ b/tests/app/snippets/navigation/router-extensions.ts
@@ -4,8 +4,9 @@ import { RouterExtensions } from "nativescript-angular/router";
 @Component({
     // ...
     // >> (hide)
+    moduleId: module.id,
     selector: "router-extensions-import",
-    templateUrl: "snippets/navigation/router-extensions.html"
+    templateUrl: "router-extensions.html"
     // << (hide)
 })
 export class MyComponent {

--- a/tests/hooks/after-prepare/nativescript-unit-test-runner.js
+++ b/tests/hooks/after-prepare/nativescript-unit-test-runner.js
@@ -1,1 +1,1 @@
-module.exports = require("nativescript-unit-test-runner/lib/after-prepare");
+module.exports = require("nativescript-unit-test-runner/./lib/after-prepare.js");

--- a/tests/karma.conf.js
+++ b/tests/karma.conf.js
@@ -1,6 +1,5 @@
-module.exports = function(config) {
-  config.set({
-    browserNoActivityTimeout: 40000,
+module.exports = function (config) {
+  const options = {
 
     // base path that will be used to resolve all patterns (eg. files, exclude)
     basePath: '',
@@ -12,6 +11,8 @@ module.exports = function(config) {
 
 
     // list of files / patterns to load in the browser
+    // files: ['app/tests/**/*.ts'],
+
     files: [
       'app/tests/test-main.js',
       'app/**/*.js',
@@ -32,7 +33,7 @@ module.exports = function(config) {
     // test results reporter to use
     // possible values: 'dots', 'progress'
     // available reporters: https://npmjs.org/browse/keyword/karma-reporter
-    reporters: ['mocha'],
+    reporters: ['progress'],
 
 
     // web server port
@@ -49,7 +50,7 @@ module.exports = function(config) {
 
 
     // enable / disable watching file and executing tests whenever any file changes
-    autoWatch: false,
+    autoWatch: true,
 
 
     // start these browsers
@@ -74,6 +75,40 @@ module.exports = function(config) {
 
     // Continuous Integration mode
     // if true, Karma captures browsers, runs the tests and exits
-    singleRun: true
-  })
+    singleRun: false
+  };
+
+  setWebpackPreprocessor(config, options);
+  setWebpack(config, options);
+
+  config.set(options);
+}
+
+function setWebpackPreprocessor(config, options) {
+  if (config && config.bundle) {
+    if (!options.preprocessors) {
+      options.preprocessors = {};
+    }
+
+    options.files.forEach(file => {
+      if (!options.preprocessors[file]) {
+        options.preprocessors[file] = [];
+      }
+      options.preprocessors[file].push('webpack');
+    });
+  }
+}
+
+function setWebpack(config, options) {
+  if (config && config.bundle) {
+    const env = {};
+    env[config.platform] = true;
+    env.sourceMap = config.debugBrk;
+    options.webpack = require('./webpack.config')(env);
+    delete options.webpack.entry;
+    delete options.webpack.output.libraryTarget;
+
+    const invalidPluginsForUnitTesting = ["GenerateBundleStarterPlugin", "GenerateNativeScriptEntryPointsPlugin"];
+    options.webpack.plugins = options.webpack.plugins.filter(p => !invalidPluginsForUnitTesting.includes(p.constructor.name));
+  }
 }

--- a/tests/nsconfig.json
+++ b/tests/nsconfig.json
@@ -1,0 +1,5 @@
+{
+	"useLegacyWorkflow": false,
+	"appPath": "app",
+	"appResourcesPath": "app/App_Resources"
+}

--- a/tests/package.json
+++ b/tests/package.json
@@ -2,14 +2,13 @@
   "nativescript": {
     "id": "org.nativescript.ngtests",
     "tns-ios": {
-      "version": "next"
+      "version": "6.0.0-2019-06-06-144931-01"
     },
     "tns-android": {
-      "version": "next"
+      "version": "6.0.0-2019-06-10-092203-01"
     }
   },
   "name": "ngtests",
-  "main": "app.js",
   "version": "1.0.0",
   "author": "Telerik <support@telerik.com>",
   "description": "Angular tests",
@@ -36,28 +35,33 @@
     "@angular/platform-browser-dynamic": "8.0.0",
     "@angular/router": "8.0.0",
     "nativescript-angular": "../nativescript-angular",
-    "nativescript-unit-test-runner": "^0.3.4",
+    "nativescript-unit-test-runner": "~0.6.3",
     "rxjs": "~6.3.3",
     "tns-core-modules": "next",
     "zone.js": "^0.8.4"
   },
   "devDependencies": {
+    "@angular/compiler-cli": "8.0.0",
+    "@ngtools/webpack": "8.0.0",
     "@types/chai": "^4.1.4",
-    "@types/mocha": "^5.2.4",
+    "@types/karma-chai": "0.1.1",
+    "@types/mocha": "5.2.6",
     "@types/sinon": "^7.0.11",
     "babel-traverse": "6.8.0",
     "babel-types": "6.8.1",
     "babylon": "6.8.0",
-    "chai": "4.1.2",
-    "karma": "2.0.4",
+    "chai": "4.2.0",
+    "karma": "4.1.0",
     "karma-chai": "0.1.0",
     "karma-mocha": "1.3.0",
     "karma-mocha-reporter": "2.2.5",
     "karma-nativescript-launcher": "0.4.0",
     "karma-sinon": "^1.0.5",
+    "karma-webpack": "3.0.5",
     "lazy": "1.0.11",
-    "mocha": "5.2.0",
+    "mocha": "6.1.4",
     "nativescript-dev-typescript": "next",
+    "nativescript-dev-webpack": "~0.25.0-webpack-2019-06-06-120047-02",
     "sinon": "^7.3.2",
     "tslint": "^4.5.1",
     "typescript": "~3.4.5"

--- a/tests/package.json
+++ b/tests/package.json
@@ -2,10 +2,10 @@
   "nativescript": {
     "id": "org.nativescript.ngtests",
     "tns-ios": {
-      "version": "6.0.0-2019-06-06-144931-01"
+      "version": "next"
     },
     "tns-android": {
-      "version": "6.0.0-2019-06-10-092203-01"
+      "version": "next"
     }
   },
   "name": "ngtests",
@@ -61,7 +61,7 @@
     "lazy": "1.0.11",
     "mocha": "6.1.4",
     "nativescript-dev-typescript": "next",
-    "nativescript-dev-webpack": "~0.25.0-webpack-2019-06-06-120047-02",
+    "nativescript-dev-webpack": "webpack",
     "sinon": "^7.3.2",
     "tslint": "^4.5.1",
     "typescript": "~3.4.5"

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -22,7 +22,13 @@
             ]
         }
     },
+    "include": [
+        "../nativescript-angular",
+        "**/*"
+    ],
     "exclude": [
+        "../nativescript-angular/node_modules",
+        "../nativescript-angular/**/*.d.ts",
         "node_modules",
         "platforms",
         "**/*.aot",


### PR DESCRIPTION
Before this PR cab be merged [this PR](https://github.com/NativeScript/nativescript-cli/pull/4550) needs to be merged into the CLI master branch and it needs to be released as a `next` tag. After that we can change the `webpack` tag used in the PR to `next`
 
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-angular/blob/master/DevelopmentWorkflow.md#running-the-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
The following applications do not work correctly when `--bundle` is enabled:
- `tests`
- `e2e/router-tab-view`
- `e2e/nested-router-tab-view`
- `e2e/modal-navigation-ng`

## What is the new behavior?
The following applications work correctly when `--bundle` is enabled:
- `tests`
- `e2e/router-tab-view`
- `e2e/nested-router-tab-view`
- `e2e/modal-navigation-ng`
