### PR TITLE
refactor: remove deprecated API usage

### DIFF
--- a/nativescript-angular/view-util.ts
+++ b/nativescript-angular/view-util.ts
@@ -365,7 +365,7 @@ export class ViewUtil {
         }
 
         if (XML_ATTRIBUTES.indexOf(attributeName) !== -1) {
-            view._applyXmlAttribute(attributeName, value);
+            view[attributeName] = value;
             return;
         }
 


### PR DESCRIPTION
The `_applyXmlAttribute` is removed - it is no longer needed.