### PR TITLE
fix: use cwd() as backup for getting path

### DIFF
--- a/nativescript-angular/bin/update-app-ng-deps
+++ b/nativescript-angular/bin/update-app-ng-deps
@@ -56,7 +56,7 @@ function updateDeps(deps, devDeps, newDeps) {
 }
 
 const pluginDeps = pluginPackageJson.peerDependencies;
-const projectPath = process.env.INIT_CWD || path.dirname(path.dirname(pluginPath));
+const projectPath = process.env.INIT_CWD || process.cwd() || path.dirname(path.dirname(pluginPath));
 const appPackageJsonPath = path.join(projectPath, "package.json");
 const appPackageJson = JSON.parse(fs.readFileSync(appPackageJsonPath, "utf8"));
 


### PR DESCRIPTION
Otherwise, Travis CI fails after using scoped deps like:
https://travis-ci.org/NativeScript/nativescript-camera/jobs/601011779