### PR TITLE
refactor: deprecated topmost() usage

### DIFF
--- a/nativescript-angular/directives/dialogs.ts
+++ b/nativescript-angular/directives/dialogs.ts
@@ -17,7 +17,7 @@ import { AppHostView } from "../app-host-view";
 import { DetachedLoader } from "../common/detached-loader";
 import { PageFactory, PAGE_FACTORY } from "../platform-providers";
 import { once } from "../common/utils";
-import { topmost, Frame } from "tns-core-modules/ui/frame";
+import { Frame } from "tns-core-modules/ui/frame";
 import { ShowModalOptions } from "tns-core-modules/ui/core/view";
 
 export type BaseShowModalOptions = Pick<ShowModalOptions, Exclude<keyof ShowModalOptions, "closeCallback" | "context">>;
@@ -86,7 +86,7 @@ export class ModalDialogService {
 
         let frame = parentView;
         if (!(parentView instanceof Frame)) {
-            frame = (parentView.page && parentView.page.frame) || topmost();
+            frame = (parentView.page && parentView.page.frame) || Frame.topmost();
         }
 
         this.location._beginModalNavigation(frame);

--- a/nativescript-angular/platform-providers.ts
+++ b/nativescript-angular/platform-providers.ts
@@ -1,6 +1,6 @@
 import { InjectionToken, Injectable } from "@angular/core";
 
-import { topmost, Frame } from "tns-core-modules/ui/frame";
+import { Frame } from "tns-core-modules/ui/frame";
 import { View } from "tns-core-modules/ui/core/view";
 import { Page } from "tns-core-modules/ui/page";
 import { device, Device } from "tns-core-modules/platform";
@@ -26,7 +26,7 @@ export function getDefaultPage(): Page {
         return rootPage;
     }
 
-    const frame = topmost();
+    const frame = Frame.topmost();
     if (frame && frame.currentPage) {
         return frame.currentPage;
     }
@@ -38,7 +38,7 @@ export const defaultPageProvider = { provide: Page, useFactory: getDefaultPage }
 
 // Use an exported function to make the AoT compiler happy.
 export function getDefaultFrame(): Frame {
-    return topmost();
+    return Frame.topmost();
 }
 
 export const defaultFrameProvider = { provide: Frame, useFactory: getDefaultFrame };
@@ -67,7 +67,7 @@ export const defaultPageFactoryProvider = { provide: PAGE_FACTORY, useValue: def
 export class FrameService {
     // TODO: Add any methods that are needed to handle frame/page navigation
     getFrame(): Frame {
-        let topmostFrame = topmost();
+        let topmostFrame = Frame.topmost();
         return topmostFrame;
     }
 }

--- a/nativescript-angular/router/ns-location-strategy.ts
+++ b/nativescript-angular/router/ns-location-strategy.ts
@@ -411,7 +411,7 @@ export class NSLocationStrategy extends LocationStrategy {
             this._modalNavigationDepth--;
         }
 
-        // currentOutlet should be the one that corresponds to the topmost() frame
+        // currentOutlet should be the one that corresponds to the topmost frame
         const topmostOutlet = this.getOutletByFrame(this.frameService.getFrame());
         const outlet = this.findOutletByModal(this._modalNavigationDepth, isShowingModal) || topmostOutlet;
 

--- a/nativescript-angular/testing/src/util.ts
+++ b/nativescript-angular/testing/src/util.ts
@@ -1,6 +1,6 @@
 
 import { View } from "tns-core-modules/ui/core/view";
-import { topmost } from "tns-core-modules/ui/frame";
+import { Frame } from "tns-core-modules/ui/frame";
 import { LayoutBase } from "tns-core-modules/ui/layouts/layout-base";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { NgModule, Type } from "@angular/core";
@@ -17,7 +17,7 @@ const TESTING_ROOT_ID = "__testing_container";
  * Get a reference to the fixtures container.
  */
 export function testingRootView(): LayoutBase {
-    const rootPageLayout = topmost().currentPage.content as LayoutBase;
+    const rootPageLayout = Frame.topmost().currentPage.content as LayoutBase;
 
     let testingRoot: LayoutBase;
     rootPageLayout.eachChild(child => {


### PR DESCRIPTION
Deprecated with https://github.com/NativeScript/NativeScript/pull/7911 in favor of static Frame.topmost().