### PR TITLE
chore: add background color to modal in example

### DIFF
--- a/e2e/tests-app-ng/app/lazy/lazy.component.css
+++ b/e2e/tests-app-ng/app/lazy/lazy.component.css
@@ -1,0 +1,8 @@
+
+.system-background-color-stack-layout {
+    background-color: white;
+}
+
+.ns-dark .system-background-color-stack-layout {
+    background-color: gray;
+}

--- a/e2e/tests-app-ng/app/lazy/lazy.component.html
+++ b/e2e/tests-app-ng/app/lazy/lazy.component.html
@@ -1,4 +1,4 @@
-<StackLayout>
+<StackLayout class="system-background-color-stack-layout">
     <GridLayout rows="auto" columns="auto" [visibility]="isModal ? 'visible' : 'collapsed'">
         <Button
             automationText="closeModal"

--- a/e2e/tests-app-ng/app/lazy/lazy.component.ts
+++ b/e2e/tests-app-ng/app/lazy/lazy.component.ts
@@ -7,6 +7,7 @@ import { ModalDialogParams } from "nativescript-angular/directives/dialogs";
     selector: "ns-lazy",
     moduleId: module.id,
     templateUrl: "./lazy.component.html",
+    styleUrls: ["./lazy.component.css"]
 })
 export class LazyComponent {
     public isModal: boolean;

--- a/e2e/tests-app-ng/package.json
+++ b/e2e/tests-app-ng/package.json
@@ -21,7 +21,7 @@
     "@angular/platform-browser": "~8.2.0",
     "@angular/platform-browser-dynamic": "~8.2.0",
     "@angular/router": "~8.2.0",
-    "nativescript-angular": "file:../../nativescript-angular",
+    "nativescript-angular": "file:../../nativescript-angular-package",
     "nativescript-intl": "~3.0.0",
     "nativescript-theme-core": "^1.0.4",
     "reflect-metadata": "~0.1.8",
@@ -38,7 +38,7 @@
     "codelyzer": "^5.1.0",
     "filewalker": "^0.1.3",
     "lazy": "1.0.11",
-    "nativescript-dev-webpack": "next",
+    "nativescript-dev-webpack": "rc",
     "tslint": "^5.4.3",
     "typescript": "~3.5.3"
   },

--- a/e2e/tests-app-ng/package.json
+++ b/e2e/tests-app-ng/package.json
@@ -38,7 +38,7 @@
     "codelyzer": "^5.1.0",
     "filewalker": "^0.1.3",
     "lazy": "1.0.11",
-    "nativescript-dev-webpack": "rc",
+    "nativescript-dev-webpack": "next",
     "tslint": "^5.4.3",
     "typescript": "~3.5.3"
   },

--- a/e2e/tests-app-ng/tsconfig.json
+++ b/e2e/tests-app-ng/tsconfig.json
@@ -24,10 +24,13 @@
         }
     },
     "include": [
+        "../../nativescript-angular-package",
         "../../nativescript-angular",
         "**/*"
     ],
     "exclude": [
+        "../../nativescript-angular-package/node_modules",
+        "../../nativescript-angular-package/**/*.d.ts",
         "../../nativescript-angular/node_modules",
         "../../nativescript-angular/**/*.d.ts",
         "node_modules",


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-angular/blob/master/DevelopmentWorkflow.md#running-the-tests
- [x] Tests for the changes are included.

## What is the current behavior?
Modal window in iOS 13 is transparent.

## What is the new behavior?
Modal window in iOS 13 is not transparent. In iOS 13 the style of the modals has changed and we need ot explicitly set the `backgroundColor` of the first element that is passed to `showModal`

Fixes/Implements/Closes #[Issue Number].
Resolves https://github.com/NativeScript/nativescript-angular/issues/2012
