### PR TITLE
fix: make FileSystemResourceLoader sync

### DIFF
--- a/nativescript-angular/resource-loader.ts
+++ b/nativescript-angular/resource-loader.ts
@@ -16,12 +16,12 @@ export class FileSystemResourceLoader extends ResourceLoader {
         super();
     }
 
-    get(url: string): Promise<string> {
+    get(url: string): string {
         const resolvedPath = this.resolve(url);
 
         const templateFile = this.fs.fileFromPath(resolvedPath);
 
-        return templateFile.readText();
+        return templateFile.readTextSync();
     }
 
     resolve(url: string): string {


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-angular/blob/master/DevelopmentWorkflow.md#running-the-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
Since https://github.com/NativeScript/NativeScript/pull/7671 `File. readText()` no longer resolves synchronously. This causes a `Bootstrap promise didn't resolve` error on startup for playground projects.

## What is the new behavior?
Use `readTextSync()` method in the `FileSystemResourceLoader` so that resources are resolved synchronously again.

