### PR TITLE
fix(hmr): After HMR app is blank when re-launched

### DIFF
--- a/nativescript-angular/platform-common.ts
+++ b/nativescript-angular/platform-common.ts
@@ -191,18 +191,7 @@ export class NativeScriptPlatformRef extends PlatformRef {
     @profile
     private bootstrapNativeScriptApp() {
         const autoCreateFrame = !!this.appOptions.createFrameOnBootstrap;
-        let tempAppHostView: AppHostView;
         let rootContent: View;
-
-        if (autoCreateFrame) {
-            const { page, frame } = this.createFrameAndPage(false);
-            setRootPage(page);
-            rootContent = frame;
-        } else {
-            // Create a temp page for root of the renderer
-            tempAppHostView = new AppHostView();
-            setRootPage(<any>tempAppHostView);
-        }
 
         if (isLogEnabled()) {
             bootstrapLog("NativeScriptPlatform bootstrap started.");
@@ -212,6 +201,17 @@ export class NativeScriptPlatformRef extends PlatformRef {
             (args: LaunchEventData) => {
                 if (isLogEnabled()) {
                     bootstrapLog("Application launch event fired");
+                }
+
+                let tempAppHostView: AppHostView;
+                if (autoCreateFrame) {
+                    const { page, frame } = this.createFrameAndPage(false);
+                    setRootPage(page);
+                    rootContent = frame;
+                } else {
+                    // Create a temp page for root of the renderer
+                    tempAppHostView = new AppHostView();
+                    setRootPage(<any>tempAppHostView);
                 }
 
                 let bootstrapPromiseCompleted = false;


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-angular/blob/master/DevelopmentWorkflow.md#running-the-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
Can be reproduced with the hello-word template on Android:

1. Create an app an run it
1. Make a change in `item.service.ts` to trigger HMR
1. Exit the app with the back button
1. Run the app again - it is blank

## What is the new behavior?
The app is rendered as expected after re-launch.

The actual problem fixed is that the `launchCallback` was using an outdated instance of `AppHostView` instead of creating new host view on every launch.
