### PR TITLE
fix(detached-loader): completely deatch components

### DIFF
--- a/nativescript-angular/common/detached-loader.ts
+++ b/nativescript-angular/common/detached-loader.ts
@@ -11,10 +11,9 @@ import { Trace } from '@nativescript/core';
 	template: `<Placeholder #loader></Placeholder>`,
 })
 export class DetachedLoader implements OnDestroy {
-
 	private disposeFunctions: Array<() => void> = [];
 	// tslint:disable-line:component-class-suffix
-	constructor(private resolver: ComponentFactoryResolver, private changeDetector: ChangeDetectorRef, private containerRef: ViewContainerRef, private appRef: ApplicationRef) { }
+	constructor(private resolver: ComponentFactoryResolver, private changeDetector: ChangeDetectorRef, private containerRef: ViewContainerRef, private appRef: ApplicationRef) {}
 
 	private loadInLocation(componentType: Type<any>): Promise<ComponentRef<any>> {
 		const factory = this.resolver.resolveComponentFactory(componentType);
@@ -25,7 +24,6 @@ export class DetachedLoader implements OnDestroy {
 			this.appRef.detachView(componentRef.hostView);
 			componentRef.destroy();
 		});
-
 
 		// Component is created, built may not be checked if we are loading
 		// inside component with OnPush CD strategy. Mark us for check to be sure CD will reach us.

--- a/nativescript-angular/common/detached-loader.ts
+++ b/nativescript-angular/common/detached-loader.ts
@@ -1,4 +1,4 @@
-import { ComponentRef, ComponentFactory, ViewContainerRef, Component, Type, ComponentFactoryResolver, ChangeDetectorRef } from '@angular/core';
+import { ComponentRef, ComponentFactory, ViewContainerRef, Component, Type, ComponentFactoryResolver, ChangeDetectorRef, ApplicationRef, OnDestroy } from '@angular/core';
 import { Trace } from '@nativescript/core';
 
 /**
@@ -10,13 +10,22 @@ import { Trace } from '@nativescript/core';
 	selector: 'DetachedContainer',
 	template: `<Placeholder #loader></Placeholder>`,
 })
-export class DetachedLoader {
+export class DetachedLoader implements OnDestroy {
+
+	private disposeFunctions: Array<() => void> = [];
 	// tslint:disable-line:component-class-suffix
-	constructor(private resolver: ComponentFactoryResolver, private changeDetector: ChangeDetectorRef, private containerRef: ViewContainerRef) {}
+	constructor(private resolver: ComponentFactoryResolver, private changeDetector: ChangeDetectorRef, private containerRef: ViewContainerRef, private appRef: ApplicationRef) { }
 
 	private loadInLocation(componentType: Type<any>): Promise<ComponentRef<any>> {
 		const factory = this.resolver.resolveComponentFactory(componentType);
-		const componentRef = this.containerRef.createComponent(factory, this.containerRef.length, this.containerRef.injector);
+		const componentRef = factory.create(this.containerRef.injector);
+		this.appRef.attachView(componentRef.hostView);
+
+		this.disposeFunctions.push(() => {
+			this.appRef.detachView(componentRef.hostView);
+			componentRef.destroy();
+		});
+
 
 		// Component is created, built may not be checked if we are loading
 		// inside component with OnPush CD strategy. Mark us for check to be sure CD will reach us.
@@ -25,6 +34,10 @@ export class DetachedLoader {
 		Trace.write('DetachedLoader.loadInLocation component loaded -> markForCheck', 'detached-loader');
 
 		return Promise.resolve(componentRef);
+	}
+
+	public ngOnDestroy() {
+		this.disposeFunctions.forEach((fn) => fn());
 	}
 
 	public detectChanges() {


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-angular/blob/master/DevelopmentWorkflow.md#running-the-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
Detached Loader (DetachedContainer) creates components in place, attaching to a detached ProxyViewContainer and then moving the native views to their appropriate position:

```
Application
|----AppComponent
|      |---------- Component1
|                       |---------- ListView1
|                       |---------- DetachedContainer (not actually added to the DOM!)
|                                        |---------- ModalView/ListView item/etc (Ng view attached to DetachedContainer, native view attached to modal window/ListView1)
```

## What is the new behavior?
Detached Loader will instantiate components without adding them to the DOM at all, but instead attaching the angular view to the ApplicationRef (enabling change detection). This also fixes issues where modals opened inside a `OnPush` component would not be CD.

This approach mimics the `@angular/cdk` approach (portals and DomPortalOutlet).

```
Application
|----AppComponent
|      |---------- Component1
|                       |---------- ListView1
|                       |---------- DetachedContainer (not actually added to the DOM! Here for compatibility reasons)
|--- ModalView/ListView item/etc (native view attached to modal window/ListView1)
```

This doesn't fix the root cause of #2256, but should fix most of the issues until the root is fixed (`createComponent` function of ViewContainerRef).

Fixes #2256.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

