### PR TITLE
fix(ivy): support view references in insertBefore

### DIFF
--- a/nativescript-angular/renderer.ts
+++ b/nativescript-angular/renderer.ts
@@ -31,7 +31,8 @@ export class NativeScriptRenderer extends Renderer2 {
 	}
 
 	@profile
-	insertBefore(parent: NgView, newChild: NgView, { previous, next }: ElementReference): void {
+	insertBefore(parent: NgView, newChild: NgView, refChild: NgView | ElementReference): void {
+		let { previous, next } = refChild instanceof View ? this.nextSibling(refChild) : refChild;
 		if (NativeScriptDebug.isLogEnabled()) {
 			NativeScriptDebug.rendererLog(`NativeScriptRenderer.insertBefore child: ${newChild} ` + `parent: ${parent} previous: ${previous} next: ${next}`);
 		}


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-angular/blob/master/DevelopmentWorkflow.md#running-the-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
When using ViewEngine, insertBefore is always called with the result of `nextSibling`. On Ivy this has changed so the View itself is returned. The current implementation will ignore view order when running with ivy

## What is the new behavior?
Support view references to be passed to insertBefore, fixing positioning issues.

Fixes #2176 #2249.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

