### PR TITLE
fix(renderer): order not preserved

### DIFF
--- a/nativescript-angular/element-registry.ts
+++ b/nativescript-angular/element-registry.ts
@@ -9,6 +9,7 @@ export interface ViewExtensions {
 	nodeName: string;
 	parentNode: NgView;
 	nextSibling: NgView;
+	previousSibling: NgView;
 	firstChild: NgView;
 	lastChild: NgView;
 	ngCssClasses: Map<string, boolean>;
@@ -22,6 +23,7 @@ export abstract class InvisibleNode extends View implements NgView {
 	nodeName: string;
 	parentNode: NgView;
 	nextSibling: NgView;
+	previousSibling: NgView;
 	firstChild: NgView;
 	lastChild: NgView;
 	ngCssClasses: Map<string, boolean>;

--- a/nativescript-angular/renderer.ts
+++ b/nativescript-angular/renderer.ts
@@ -6,11 +6,6 @@ import { ViewUtil } from './view-util';
 import { NgView, InvisibleNode } from './element-registry';
 import { NativeScriptDebug } from './trace';
 
-export interface ElementReference {
-	previous: NgView;
-	next: NgView;
-}
-
 @Injectable()
 export class NativeScriptRenderer extends Renderer2 {
 	data: { [key: string]: any } = Object.create(null);
@@ -31,8 +26,8 @@ export class NativeScriptRenderer extends Renderer2 {
 	}
 
 	@profile
-	insertBefore(parent: NgView, newChild: NgView, refChild: NgView | ElementReference): void {
-		let { previous, next } = refChild instanceof View ? this.nextSibling(refChild) : refChild;
+	insertBefore(parent: NgView, newChild: NgView, refChild: NgView): void {
+		let { previous, next } = refChild instanceof View ? { previous: refChild.previousSibling, next: refChild } : { previous: null, next: null };
 		if (NativeScriptDebug.isLogEnabled()) {
 			NativeScriptDebug.rendererLog(`NativeScriptRenderer.insertBefore child: ${newChild} ` + `parent: ${parent} previous: ${previous} next: ${next}`);
 		}
@@ -68,15 +63,12 @@ export class NativeScriptRenderer extends Renderer2 {
 	}
 
 	@profile
-	nextSibling(node: NgView): ElementReference {
+	nextSibling(node: NgView): NgView {
 		if (NativeScriptDebug.isLogEnabled()) {
 			NativeScriptDebug.rendererLog(`NativeScriptRenderer.nextSibling of ${node} is ${node.nextSibling}`);
 		}
 
-		return {
-			previous: node,
-			next: node.nextSibling,
-		};
+		return node.nextSibling;
 	}
 
 	@profile

--- a/nativescript-angular/view-util.ts
+++ b/nativescript-angular/view-util.ts
@@ -63,12 +63,14 @@ export class ViewUtil {
 
 		if (previous) {
 			previous.nextSibling = child;
+			child.previousSibling = previous;
 		} else {
 			parent.firstChild = child;
 		}
 
 		if (next) {
 			child.nextSibling = next;
+			next.previousSibling = child;
 		} else {
 			this.appendToQueue(parent, child);
 		}
@@ -81,6 +83,7 @@ export class ViewUtil {
 
 		if (parent.lastChild) {
 			parent.lastChild.nextSibling = view;
+			view.previousSibling = parent.lastChild;
 		}
 
 		parent.lastChild = view;
@@ -152,6 +155,7 @@ export class ViewUtil {
 			parent.firstChild = null;
 			parent.lastChild = null;
 			child.nextSibling = null;
+			child.previousSibling = null;
 			return;
 		}
 
@@ -159,16 +163,20 @@ export class ViewUtil {
 			parent.firstChild = child.nextSibling;
 		}
 
-		const previous = this.findPreviousElement(parent, child);
+		const previous = child.previousSibling;
 		if (parent.lastChild === child) {
 			parent.lastChild = previous;
 		}
 
 		if (previous) {
 			previous.nextSibling = child.nextSibling;
+			if (child.nextSibling) {
+				child.nextSibling.previousSibling = previous;
+			}
 		}
 
 		child.nextSibling = null;
+		child.previousSibling = null;
 	}
 
 	// NOTE: This one is O(n) - use carefully


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-angular/blob/master/DevelopmentWorkflow.md#running-the-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
Ordering can be erratic when nesting ng-containers and templates. This is due to `previousSibling` not being implemented and comment nodes not being properly respected

```html
<ng-container>
  <Label text="1" *ngIf="show"></Label>
  <Label text="2" *ngIf="show"></Label>
</ng-container>
```

will render:

2
1

## What is the new behavior?
The node list is now doubly linked (`previousSibling` and `nextSibling`), allowing for faster processing of previousSibling and respecting the positioning of commentnodes.

```html
<ng-container>
  <Label text="1" *ngIf="show"></Label>
  <Label text="2" *ngIf="show"></Label>
</ng-container>
```

will render
1
2

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

