### PR TITLE
fix: Export injection token used by plugins

### DIFF
--- a/nativescript-angular/directives/index.ts
+++ b/nativescript-angular/directives/index.ts
@@ -1,5 +1,5 @@
 import { ListViewComponent } from './list-view-comp';
-import { TemplateKeyDirective, TemplatedItemsComponent } from './templated-items-comp';
+import { TemplateKeyDirective, TemplatedItemsComponent, TEMPLATED_ITEMS_COMPONENT } from './templated-items-comp';
 import { TabViewDirective, TabViewItemDirective } from './tab-view';
 import { ActionBarComponent, ActionBarScope, ActionItemDirective, NavigationButtonDirective } from './action-bar';
 import { AndroidFilterComponent, IosFilterComponent } from './platform-filters';


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-angular/blob/master/DevelopmentWorkflow.md#running-the-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
The `TEMPLATED_ITEMS_COMPONENT` injection token is missing from the export, thus preventing ability to create plugins/other components that extend the `TemplatedItemsComponent`

## What is the new behavior?
The `TEMPLATED_ITEMS_COMPONENT` is re-exported

Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

