### PR TITLE
fix: Cannot reattach ActivatedRouteSnapshot created from a different …

### DIFF
--- a/nativescript-angular/router/ns-route-reuse-strategy.ts
+++ b/nativescript-angular/router/ns-route-reuse-strategy.ts
@@ -12,6 +12,10 @@ interface CacheItem {
 }
 
 const getSnapshotKey = function (snapshot: ActivatedRouteSnapshot): string {
+	// https://github.com/angular/angular/issues/13869#issuecomment-344403045
+	while (snapshot.firstChild) {
+		snapshot = snapshot.firstChild;
+	}
 	return snapshot.pathFromRoot.join('->');
 };
 


### PR DESCRIPTION
…route

<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-angular/blob/master/DevelopmentWorkflow.md#running-the-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
Navigating between sibling routes may sometimes mess with the cache due to it using the key of a parent route, instead of the complete route.

## What is the new behavior?
This now uses the correct key from the farthest children of the route

PARTIALLY Fixes #1993. (this issue has 2 problems on it: 1 is the one fixed in this PR, the other is that route guard/resolvers don't work on back navigation and may break navigation for a PRO)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

