### PR TITLE
Clear all outletKeys instead of only the first

### DIFF
--- a/nativescript-angular/router/page-router-outlet.ts
+++ b/nativescript-angular/router/page-router-outlet.ts
@@ -329,7 +329,9 @@ export class PageRouterOutlet implements OnDestroy {
 			const clearCallback = () =>
 				setTimeout(() => {
 					if (this.outlet) {
-						this.routeReuseStrategy.clearCache(this.outlet.outletKeys[0]);
+						this.outlet.outletKeys.forEach((outletKey) => {
+							this.routeReuseStrategy.clearCache(outletKey);
+						});
 					}
 				});
 


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] You have signed the [CLA](http://www.nativescript.org/cla).
- [ ] All existing tests are passing: https://github.com/NativeScript/nativescript-angular/blob/master/DevelopmentWorkflow.md#running-the-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
Only the first outletKey of the outlet is used to destroy past views.

## What is the new behavior?
All outletKeys of the outlet is used to destroy past views.

Fixes #2303.

