### PR TITLE
fix: polyfill global.Node for angular testing

### DIFF
--- a/nativescript-angular/testing/src/polyfills.ts
+++ b/nativescript-angular/testing/src/polyfills.ts
@@ -1,0 +1,4 @@
+if (typeof Node === 'undefined' && !global.Node) {
+	class DummyNode {}
+	global.Node = DummyNode as any;
+}

--- a/nativescript-angular/testing/src/public_api.ts
+++ b/nativescript-angular/testing/src/public_api.ts
@@ -1,3 +1,4 @@
+import './polyfills';
 export * from './util';
 export * from './test-root-view';
 export * from './nativescript_test_component_renderer';


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] You have signed the [CLA](http://www.nativescript.org/cla).
- [x] All existing tests are passing: https://github.com/NativeScript/nativescript-angular/blob/master/DevelopmentWorkflow.md#running-the-tests
- [ ] Tests for the changes are included.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Angular 11 introduced a regression where they check `instanceof Node`, but Node is not polyfilled by Nativescript so it errors out.

## What is the new behavior?
Node is polyfilled with a dummy class.

Fixes #2311.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:


[Describe the impact of the changes here.]

Migration steps:
[Provide a migration path for existing applications.]
-->

